### PR TITLE
feat: rename blacklist to omitProps

### DIFF
--- a/packages/clean-tag/README.md
+++ b/packages/clean-tag/README.md
@@ -45,15 +45,15 @@ Changes the underlying HTML element per component instance.
 <Heading is='h1' />
 ```
 
-## `blacklist` prop
+## `omitProps` prop
 
-Provide a custom blacklist of prop names.
+Provide a custom list of prop keys to remove from the backing styled component.
 
-The default blacklist is based on Styled System's propType definitions.
+The default list is based on Styled System's propType definitions.
 
 ```js
 <Heading
-  blacklist={[
+  omitProps={[
     'fontSize',
     'color'
   ]}

--- a/packages/clean-tag/index.js
+++ b/packages/clean-tag/index.js
@@ -6,7 +6,7 @@ const allPropTypes = Object.keys(styles)
   .filter(key => typeof styles[key] === 'function')
   .reduce((a, key) => Object.assign(a, styles[key].propTypes), {})
 
-const blacklist = [ ...Object.keys(allPropTypes), 'theme' ]
+const omitProps = [ ...Object.keys(allPropTypes), 'theme' ]
 
 export const omit = (obj, keys) => {
   const next = {}
@@ -19,17 +19,17 @@ export const omit = (obj, keys) => {
 
 export const Tag = React.forwardRef(({
   is: Tag = 'div',
-  blacklist = [],
+  omitProps = [],
   ...props
 }, ref) => React.createElement(Tag, {
   ref,
-  ...omit(props, blacklist)
+  ...omit(props, omitProps)
 }))
 
 Tag.displayName = 'Clean.div'
 
 Tag.defaultProps = {
-  blacklist
+  omitProps: omitProps
 }
 
 tags.forEach(tag => {

--- a/packages/clean-tag/test.js
+++ b/packages/clean-tag/test.js
@@ -31,7 +31,7 @@ test('exports html tags', t => {
   t.is(header.type, 'header')
 })
 
-test('exported html tags only omit blacklisted props', t => {
+test('exported html tags only omits props', t => {
   const json = render(React.createElement(tag.h1, {
     id: 'hello',
     m: 2,
@@ -51,10 +51,10 @@ test('accepts an is prop to change the underlying element', t => {
   t.is(json.type, 'header')
 })
 
-test('accepts a custom blacklist', t => {
+test('accepts custom omitProps', t => {
   const json = render(React.createElement(tag, {
     hello: 'hi',
-    blacklist: [ 'hello' ]
+    omitProps: [ 'hello' ]
   })).toJSON()
   t.is(json.props.hello, undefined)
 })


### PR DESCRIPTION
fixes #391

BREAKING CHANGE: `blacklist` has been renamed to `omitProps`, so consumers
will need to change this.