### PR TITLE
Fix border props sequence

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -471,11 +471,11 @@ export const borders = compose(
   border,
   borderStyle,
   borderWidth,
-  borderColor,
   borderTop,
   borderRight,
   borderBottom,
   borderLeft,
+  borderColor,
   borderRadius
 )
 

--- a/src/index.js
+++ b/src/index.js
@@ -469,12 +469,12 @@ export const borderRadius = style({
 
 export const borders = compose(
   border,
-  borderStyle,
-  borderWidth,
   borderTop,
   borderRight,
   borderBottom,
   borderLeft,
+  borderWidth,
+  borderStyle,
   borderColor,
   borderRadius
 )

--- a/test/styles.js
+++ b/test/styles.js
@@ -8,9 +8,9 @@ import {
   gridGap,
   gridRowGap,
   gridColumnGap,
-  buttonStyle,
   textStyle,
   colorStyle,
+  borders,
 } from '../src'
 
 const theme = {
@@ -323,4 +323,9 @@ test('colors prop returns theme.colorStyles object', t => {
     color: '#fff',
     backgroundColor: '#000',
   })
+})
+
+test('borders prop returns correct sequence', t => {
+  const a = borders({ borderBottom: '1px solid', borderColor: 'red' })
+  t.deepEqual(a, [{ borderBottom: '1px solid' }, { borderColor: 'red' }])
 })

--- a/test/styles.js
+++ b/test/styles.js
@@ -326,6 +326,16 @@ test('colors prop returns theme.colorStyles object', t => {
 })
 
 test('borders prop returns correct sequence', t => {
-  const a = borders({ borderBottom: '1px solid', borderColor: 'red' })
-  t.deepEqual(a, [{ borderBottom: '1px solid' }, { borderColor: 'red' }])
+  const a = borders({
+    borderBottom: '1px solid',
+    borderWidth: '2px',
+    borderStyle: 'dashed',
+    borderColor: 'red',
+  })
+  t.deepEqual(a, [
+    { borderBottom: '1px solid' },
+    { borderWidth: '2px' },
+    { borderStyle: 'dashed' },
+    { borderColor: 'red' },
+  ])
 })


### PR DESCRIPTION
Fixes following issue:

let's say we have a component:
```js
const Component = () => styled.div`
  ${borders}
`
```
then we render it with the following props:
```js
<Component borderBottom="1px solid" borderColor="red" />
```
than CSS will be:
```css
border-color: red;
border-bottom: 1px solid;
```
the `red` color will be replaced with `inherit` which is `#000` in Chrome 72
