### PR TITLE
Fix createGlobalStyle in Basic Example

### DIFF
--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -13,10 +13,10 @@ import {
   lineHeight,
 } from 'styled-system'
 
-const Style = createGlobalStyle(`
+const Style = createGlobalStyle`
   * { box-sizing: border-box; }
   body{ margin:0; }
-`)
+`
 
 const theme = {
   fontSizes: [


### PR DESCRIPTION
createGlobalStyle should not be invoked as a function

Just a beginner here — I noticed that createGlobalStyle does not work as a function call in Basic Example. Was this a mistake?