### PR TITLE
Prevent max call stack when merging overlapping keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,12 +42,10 @@ export const merge = (a, b) => {
     result[key] = a[key]
   }
   for (const key in b) {
-    if (!a[key]) {
+    if (!a[key] || typeof a[key] !== 'object') {
       result[key] = b[key]
-    } else if (typeof a[key] === 'object') {
-      result[key] = merge(a[key], b[key])
     } else {
-      result[key] = b[key]
+      result[key] = merge(a[key], b[key])
     }
   }
   return result

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,10 @@ export const merge = (a, b) => {
   for (const key in b) {
     if (!a[key]) {
       result[key] = b[key]
-    } else {
+    } else if (typeof a[key] === 'object') {
       result[key] = merge(a[key], b[key])
+    } else {
+      result[key] = b[key]
     }
   }
   return result

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ import {
   cloneFunction,
   mapProps,
   merge,
+  fontSize,
 } from '../src'
 
 const width = style({
@@ -287,5 +288,29 @@ test('merge deeply merges', t => {
       merge: 'me',
       and: 'all of us'
     }
+  })
+})
+
+test('variant can be composed', t => {
+  const system = compose(
+    variant({ key: 'typography' }),
+    fontSize,
+    color
+  )
+  const result = system({
+    theme: {
+      typography: {
+        primary: {
+          fontSize: '32px',
+          color: '#fff'
+        },
+      },
+    },
+    variant: 'primary',
+    color: '#111'
+  })
+  t.deepEqual(result, {
+    fontSize: '32px',
+    color: '#111'
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -277,13 +277,15 @@ test('mapProps copies propTypes', t => {
 
 test('merge deeply merges', t => {
   const result = merge(
-    { hello: { hi: 'beep' } },
-    { hello: { hey: 'boop' } },
+    { hello: { hi: 'beep', merge: 'me', and: 'me' } },
+    { hello: { hey: 'boop', merge: 'me', and: 'all of us' } },
   )
   t.deepEqual(result, {
     hello: {
       hi: 'beep',
       hey: 'boop',
+      merge: 'me',
+      and: 'all of us'
     }
   })
 })


### PR DESCRIPTION
The [`merge`](https://github.com/styled-system/styled-system/blob/master/src/index.js#L38-L60) function added in #473 expects all keys to be unique across merged objects, otherwise it will trigger a _max call stack_ error as it attempts to merge strings.

The merge implementation was intentionally minimal in scope, and an argument could be made for continuing to expect unique keys, but I ran into this issue with a fairly basic use-case – composing `variant` to allow overrides.

To help evaluate this PR, I added an additional test which covers this use-case. It is a bit specific so I'm not sure it should land in master as is.

