### PR TITLE
Add the responsive default alias `_` to documentation

### DIFF
--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -59,7 +59,7 @@ Using Styled System with a CSS-in-JS library will generate something like the fo
 
 ## Using objects
 
-Alternatively, you can define breakpoints with aliases and use plain objects as values. Use the alias `_` to define the base value.
+Alternatively, you can define breakpoints with aliases and use plain objects as values. Any undefined alias key will define the base, non-responsive value.
 
 ```js
 // theme.js
@@ -82,7 +82,7 @@ export default {
 ```
 
 ```jsx
-<Box width={{ _: 1, sm: 1, md: 1/2, lg: 1/4 }} />
+<Box width={{ 0: 1, sm: 1, md: 1/2, lg: 1/4 }} />
 ```
 
 

--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -59,7 +59,7 @@ Using Styled System with a CSS-in-JS library will generate something like the fo
 
 ## Using objects
 
-Alternatively, you can define breakpoints with aliases and use plain objects as values.
+Alternatively, you can define breakpoints with aliases and use plain objects as values. Use the alias `_` to define the base value.
 
 ```js
 // theme.js
@@ -82,7 +82,7 @@ export default {
 ```
 
 ```jsx
-<Box width={{ sm: 1, md: 1/2, lg: 1/4 }} />
+<Box width={{ _: 1, sm: 1, md: 1/2, lg: 1/4 }} />
 ```
 
 


### PR DESCRIPTION
I had to dig into the GitHub to find how to apply a default style (my responsive elements were appearing on `< small` breakpoints!), so here's a pull request adding the `_` default to the Responsive Styles docs.

The example isn't ✨perfect✨  (since a Box would usually have an implicit 100% width anyway) but I hope it's illustrative enough.