### PR TITLE
Add `fontFamily` to `styled-system/props`

### DIFF
--- a/packages/styled-system/props.js
+++ b/packages/styled-system/props.js
@@ -32,6 +32,7 @@ module.exports = [
   'lineHeight',
   'textAlign',
   'fontStyle',
+  'fontFamily',
   'letterSpacing',
   'display',
   'maxWidth',


### PR DESCRIPTION
Noticed that it was still forwarded after giving https://styled-system.com/guides/removing-props-from-html#emotion a spin.