### PR TITLE
Use default breakpoints variable

### DIFF
--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -110,7 +110,7 @@ const transforms = {
 
 export const responsive = styles => theme => {
   const next = {}
-  const breakpoints = get(theme, 'breakpoints', [ '40em', '52em', '64em' ])
+  const breakpoints = get(theme, 'breakpoints', defaultBreakpoints)
   const mediaQueries = [ null, ...breakpoints.map(n => `@media screen and (min-width: ${n})`) ]
 
   for (const key in styles) {


### PR DESCRIPTION
Super minor detail: Getting the breakpoints didn't use the `defaultBreakpoints` from the start of the file, but rather had them declared inline.