### PR TITLE
Remove trailing slash from href in "edit page" links

### DIFF
--- a/docs/src/edit-link.js
+++ b/docs/src/edit-link.js
@@ -6,7 +6,7 @@ const base = 'https://github.com/styled-system/styled-system/edit/master/docs'
 
 const getHREF = location => {
   if (location.pathname === '/') return base + '/getting-started.md'
-  return base + location.pathname + '.md'
+  return base + location.pathname.replace(/\/+$/, '') + '.md'
 }
 
 export default () => (


### PR DESCRIPTION
This will remove one (or many) trailing slashes at the end of the URL for "edit page" links.  On the website, you'll notice that many of these links are broken when a trailing slash is included in the domain name.  Example:

**Original:** https://styled-system.com/guides/build-a-box
**Converted by router:** https://styled-system.com/guides/build-a-box/
**Resulting link:** https://github.com/styled-system/styled-system/edit/master/docs/guides/build-a-box/.md
**Desired link:** https://github.com/styled-system/styled-system/edit/master/docs/guides/build-a-box.md