### PR TITLE
Fix system export

### DIFF
--- a/packages/styled-system/src/index.js
+++ b/packages/styled-system/src/index.js
@@ -1,10 +1,11 @@
-import { createStyleFunction, createParser, system } from '@styled-system/core'
+import { createStyleFunction, createParser } from '@styled-system/core'
 
 export {
   get,
   createParser,
   createStyleFunction,
   compose,
+  system,
 } from '@styled-system/core'
 
 export { margin, padding, space } from '@styled-system/space'


### PR DESCRIPTION
[Documentation](https://styled-system.com/api#system) says that `system` should be exported from `styled-system` but it's not.
It's imported but looks like it's never used so I moved it from import to export.