### PR TITLE
Fix incorrect function name in migrating docs

### DIFF
--- a/docs/guides/migrating.md
+++ b/docs/guides/migrating.md
@@ -121,7 +121,7 @@ While the `style` utility from v4 should continue to work as expected, you can t
 
 ```js
 // v4
-const transition = styled({
+const transition = style({
   prop: 'transition',
 })
 const Box = styled('div')(transition)


### PR DESCRIPTION
Just a minor typo.

v5 is looks great!