### PR TITLE
Fix API Signature in Migrating Guide

### DIFF
--- a/docs/guides/migrating.md
+++ b/docs/guides/migrating.md
@@ -121,7 +121,7 @@ While the `style` utility from v4 should continue to work as expected, you can t
 
 ```js
 // v4
-const transition = style({
+const transition = styled({
   prop: 'transition',
 })
 const Box = styled('div')(transition)
@@ -131,7 +131,7 @@ const Box = styled('div')(transition)
 // v5
 const Box = styled('div')(
   system({
-    transition: true,
+    transform: true,
   })
 )
 ```
@@ -146,7 +146,7 @@ const Box = styled('div')(
       scale: 'fontSizes',
     },
     // shortcut syntax
-    transition: true,
+    transform: true,
   })
 )
 ```


### PR DESCRIPTION
Some minor yet significant API typo fixes.

The `system` function uses a `transition` key, where it should be `transform` ([src](https://github.com/styled-system/styled-system/blob/master/packages/core/src/index.js#L112))