### PR TITLE
Fix compose example

### DIFF
--- a/docs/guides/migrating.md
+++ b/docs/guides/migrating.md
@@ -112,7 +112,7 @@ const styleProps = compose(
   space,
   color
 )
-const Box = styled(styleProps)
+const Box = styled('div')(styleProps)
 ```
 
 ### Custom Styles


### PR DESCRIPTION
Compose example code for v5 was missing the element portion of the api.