### PR TITLE
@styled-system/should-forward-prop: Add shadow to the list of composed functions

### DIFF
--- a/packages/should-forward-prop/src/index.js
+++ b/packages/should-forward-prop/src/index.js
@@ -11,7 +11,10 @@ import {
   background,
   position,
   grid,
-  shadow
+  shadow,
+  buttonStyle,
+  textStyle,
+  colorStyle
 } from 'styled-system'
 
 const all = compose(
@@ -24,7 +27,10 @@ const all = compose(
   background,
   position,
   grid,
-  shadow
+  shadow,
+  buttonStyle,
+  textStyle,
+  colorStyle
 )
 
 export const props = all.propNames

--- a/packages/should-forward-prop/src/index.js
+++ b/packages/should-forward-prop/src/index.js
@@ -10,7 +10,8 @@ import {
   border,
   background,
   position,
-  grid
+  grid,
+  shadow
 } from 'styled-system'
 
 const all = compose(
@@ -22,7 +23,8 @@ const all = compose(
   border,
   background,
   position,
-  grid
+  grid,
+  shadow
 )
 
 export const props = all.propNames


### PR DESCRIPTION
I noticed that the default `shouldForwardProp` does not exclude from the DOM props for `shadow` and variants (`buttonStyle`, `colorStyle`, & `textStyle`). This PR adds those to the list of composed functions to exclude.