### PR TITLE
Update space variables to include px

### DIFF
--- a/docs/theme-specification.md
+++ b/docs/theme-specification.md
@@ -77,15 +77,15 @@ When defining space scales as an array, it is conventional to use the value `0` 
 
 ```js
 // example space scale
-space: [0, 4, 8, 16, 32, 64]
+space: ['0px', '4px', '8px', '16px', '32px', '64px']
 ```
 
 ```js
 // example space scale object
 space: {
-  small: 4,
-  medium: 8,
-  large: 16,
+  small: '4px',
+  medium: '8px',
+  large: '16px',
 }
 ```
 


### PR DESCRIPTION
From the [5.0 changelog](https://github.com/styled-system/styled-system/blob/master/CHANGELOG.md#v500-2019-06-02)

> No longer converts numbers to `px` strings

I think that means that all theme variables have to be updated to include a unit, at least in our project space didn't work without converting them to include `px` :)
Should all theme variables be updated to include a unit though?