### PR TITLE
Use system scale on negative positional properties

### DIFF
--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -68,6 +68,10 @@ Property  | Theme Key
 `paddingLeft`, `pl` | `space`
 `paddingX`, `px` | `space`
 `paddingY`, `py` | `space`
+`top` | `space`
+`bottom` | `space`
+`left` | `space`
+`right` | `space`
 `border` | `borders`
 `borderTop` | `borders`
 `borderRight` | `borders`

--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -57,6 +57,10 @@ const scales = {
   paddingLeft: 'space',
   paddingX: 'space',
   paddingY: 'space',
+  top: 'space',
+  right: 'space',
+  bottom: 'space',
+  left: 'space',
   fontFamily: 'fonts',
   fontSize: 'fontSizes',
   fontWeight: 'fontWeights',
@@ -85,7 +89,7 @@ const scales = {
   maxHeight: 'sizes',
 }
 
-const getMargin = (scale, value) => {
+const positiveOrNegative = (scale, value) => {
   if (typeof value !== 'number' || value >= 0) {
     return get(scale, value, value)
   }
@@ -95,20 +99,33 @@ const getMargin = (scale, value) => {
   return n * -1
 }
 
-const transforms = {
-  margin: getMargin,
-  marginTop: getMargin,
-  marginRight: getMargin,
-  marginBottom: getMargin,
-  marginLeft: getMargin,
-  marginX: getMargin,
-  marginY: getMargin,
-}
+const transforms = [
+  'margin',
+  'marginTop',
+  'marginRight',
+  'marginBottom',
+  'marginLeft',
+  'marginX',
+  'marginY',
+  'top',
+  'bottom',
+  'left',
+  'right',
+].reduce(
+  (acc, curr) => ({
+    ...acc,
+    [curr]: positiveOrNegative,
+  }),
+  {}
+)
 
 export const responsive = styles => theme => {
   const next = {}
   const breakpoints = get(theme, 'breakpoints', defaultBreakpoints)
-  const mediaQueries = [ null, ...breakpoints.map(n => `@media screen and (min-width: ${n})`) ]
+  const mediaQueries = [
+    null,
+    ...breakpoints.map(n => `@media screen and (min-width: ${n})`),
+  ]
 
   for (const key in styles) {
     const value = styles[key]

--- a/packages/css/test/index.js
+++ b/packages/css/test/index.js
@@ -226,3 +226,18 @@ test('handles negative margins from scale', () => {
     marginRight: -32,
   })
 })
+
+test('handles negative top, left, bottom, and right from scale', () => {
+  const result = css({
+    top: -1,
+    right: -4,
+    bottom: -3,
+    left: -2,
+  })(theme)
+  expect(result).toEqual({
+    top: -4,
+    right: -32,
+    bottom: -16,
+    left: -8,
+  })
+})


### PR DESCRIPTION
`top`, `bottom`, `left`, & `right` now all use system values for
negative numbers.

Additionally, this change prompted a refactor of the
transforms object into a reducer to avoid all the repetition. LMK if that's not cool.