### PR TITLE
WIP Use `css` utility in `variant` to allow theme values in variant

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -46,20 +46,20 @@ export const createParser = config => {
           ]
           styles = merge(
             styles,
-            parseResponsiveStyle(cache.media, sx, scale, raw)
+            parseResponsiveStyle(cache.media, sx, scale, raw, props)
           )
           continue
         }
         if (raw !== null) {
           styles = merge(
             styles,
-            parseResponsiveObject(cache.breakpoints, sx, scale, raw)
+            parseResponsiveObject(cache.breakpoints, sx, scale, raw, props)
           )
         }
         continue
       }
 
-      assign(styles, sx(raw, scale))
+      assign(styles, sx(raw, scale, props))
     }
 
     return styles
@@ -70,11 +70,11 @@ export const createParser = config => {
   return parse
 }
 
-const parseResponsiveStyle = (mediaQueries, sx, scale, raw) => {
+const parseResponsiveStyle = (mediaQueries, sx, scale, raw, props) => {
   let styles = {}
   raw.slice(0, mediaQueries.length).forEach((value, i) => {
     const media = mediaQueries[i]
-    const style = sx(value, scale)
+    const style = sx(value, scale, props)
     if (style === undefined) return
     if (!media) {
       assign(styles, style)
@@ -87,12 +87,12 @@ const parseResponsiveStyle = (mediaQueries, sx, scale, raw) => {
   return styles
 }
 
-const parseResponsiveObject = (breakpoints, sx, scale, raw) => {
+const parseResponsiveObject = (breakpoints, sx, scale, raw, props) => {
   let styles = {}
   for (let key in raw) {
     const breakpoint = breakpoints[key]
     const value = raw[key]
-    const style = sx(value, scale)
+    const style = sx(value, scale, props)
     if (!breakpoint) {
       assign(styles, style)
     } else {

--- a/packages/variant/package.json
+++ b/packages/variant/package.json
@@ -6,7 +6,8 @@
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@styled-system/core": "^5.0.5"
+    "@styled-system/core": "^5.0.5",
+    "@styled-system/css": "5.0.5"
   },
   "gitHead": "a6feb6009c58f2eb68f0c3120c5672f6cb54294f",
   "publishConfig": {

--- a/packages/variant/src/index.js
+++ b/packages/variant/src/index.js
@@ -1,4 +1,5 @@
 import { get, createParser } from '@styled-system/core'
+import css from '@styled-system/css'
 
 export const variant = ({
   scale,

--- a/packages/variant/src/index.js
+++ b/packages/variant/src/index.js
@@ -7,8 +7,8 @@ export const variant = ({
   // shim for v4 API
   key,
 }) => {
-  const sx = (value, scale) => {
-    return get(scale, value, null)
+  const sx = (value, scale, props) => {
+    return css(get(scale, value, null))(props.theme)
   }
   sx.scale = scale || key
   const config = {

--- a/packages/variant/test/index.js
+++ b/packages/variant/test/index.js
@@ -113,3 +113,26 @@ test('colors prop returns theme.colorStyles object', () => {
   })
 })
 
+test('variants can use theme values', () => {
+  const buttons = variant({ scale: 'buttons', })
+  const a = buttons({
+    theme: {
+      colors: {
+        primary: 'tomato',
+      },
+      buttons: {
+        primary: {
+          p: 4,
+          color: '#fff',
+          bg: 'primary',
+        },
+      },
+    },
+    variant: 'primary',
+  })
+  expect(a).toEqual({
+    color: '#fff',
+    backgroundColor: 'tomato',
+    padding: 32,
+  })
+})


### PR DESCRIPTION
Fixes #582 

- [ ] Add more unit tests to cover edge cases
- [ ] Consider overall architectural implications (currently `styled-system` does not depend on `css`)