### PR TITLE
Position: Use space scale for top/right/bottom/left

### DIFF
--- a/docs/table.md
+++ b/docs/table.md
@@ -169,10 +169,10 @@ import { position } from 'styled-system'
 | ---------- | ------------ | ----------- |
 | `position` | `position`   | none        |
 | `zIndex`   | `z-index`    | `zIndices`  |
-| `top`      | `top`        | none        |
-| `right`    | `right`      | none        |
-| `bottom`   | `bottom`     | none        |
-| `left`     | `left`       | none        |
+| `top`      | `top`        | `space`     |
+| `right`    | `right`      | `space`     |
+| `bottom`   | `bottom`     | `space`     |
+| `left`     | `left`       | `space`     |
 
 ## Shadow
 

--- a/packages/position/src/index.js
+++ b/packages/position/src/index.js
@@ -1,15 +1,35 @@
 import { system } from '@styled-system/core'
 
+const defaults = {
+  space: [0, 4, 8, 16, 32, 64, 128, 256, 512],
+}
+
 const config = {
   position: true,
   zIndex: {
     property: 'zIndex',
     scale: 'zIndices',
   },
-  top: true,
-  right: true,
-  bottom: true,
-  left: true,
+  top: {
+    property: 'top',
+    scale: 'space',
+    defaultScale: defaults.space,
+  },
+  right: {
+    property: 'right',
+    scale: 'space',
+    defaultScale: defaults.space,
+  },
+  bottom: {
+    property: 'bottom',
+    scale: 'space',
+    defaultScale: defaults.space,
+  },
+  left: {
+    property: 'left',
+    scale: 'space',
+    defaultScale: defaults.space,
+  },
 }
 
 export const position = system(config)

--- a/packages/position/test/index.js
+++ b/packages/position/test/index.js
@@ -12,3 +12,23 @@ test('returns position styles', () => {
     right: 0,
   })
 })
+
+test('returns theme values', () => {
+  const style = position({ top: 1, right: 2, bottom: 3, left: 4 })
+  expect(style).toEqual({ top: 4, right: 8, bottom: 16, left: 32 })
+})
+
+test('returns pixel values', () => {
+  const style = position({
+    top: '1px',
+    right: '2px',
+    bottom: '3px',
+    left: '4px',
+  })
+  expect(style).toEqual({
+    top: '1px',
+    right: '2px',
+    bottom: '3px',
+    left: '4px',
+  })
+})


### PR DESCRIPTION
Hi, @jxnblk 👋 

This pull request connects the `top`, `right`, `bottom` and `left` style functions in the `position` category to the `space` theme scale. If there's a reason that they shouldn't use the `space` scale feel free to close this PR 😄  

I noticed this issue when I was using the `Absolute` component from `@primer/components` and expected `<Absolute top={3}>` to render a box `16px` from the top not `3px` from the top.