### PR TITLE
Enable dynamically changed breakpoints for nested themes 

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -36,14 +36,28 @@ export const createParser = config => {
       const scale = get(props.theme, sx.scale, sx.defaults)
 
       if (typeof raw === 'object') {
-        cache.breakpoints =
-          cache.breakpoints ||
-          get(props.theme, 'breakpoints', defaults.breakpoints)
+        // If a child theme provides breakpoints, the cached ones should be updated
+        const shouldCacheBeBusted = get(props.theme, 'breakpoints', [])
+        if (shouldCacheBeBusted) {
+          cache.breakpoints = get(
+            props.theme,
+            'breakpoints',
+            defaults.breakpoints
+          )
+        } else {
+          cache.breakpoints =
+            cache.breakpoints ||
+            get(props.theme, 'breakpoints', defaults.breakpoints)
+        }
         if (Array.isArray(raw)) {
-          cache.media = cache.media || [
-            null,
-            ...cache.breakpoints.map(createMediaQuery),
-          ]
+          if (shouldCacheBeBusted) {
+            cache.media = [null, ...cache.breakpoints.map(createMediaQuery)]
+          } else {
+            cache.media = cache.media || [
+              null,
+              ...cache.breakpoints.map(createMediaQuery),
+            ]
+          }
           styles = merge(
             styles,
             parseResponsiveStyle(cache.media, sx, scale, raw)

--- a/packages/core/test/parser.js
+++ b/packages/core/test/parser.js
@@ -35,19 +35,58 @@ test('uses default breakpoints', () => {
   })
 })
 
-test('uses dynamically provided breakpoints', () => {
-  const styles = parser({
+test('uses dynamically changed breakpoints', () => {
+  const firstStyles = parser({
     theme: { ...theme, breakpoints: ['11em', '22em', '33em'] },
     fontSize: [1, 2, 3],
     color: ['primary', null, 'secondary'],
   })
-  expect(styles).toEqual({
+  expect(firstStyles).toEqual({
     color: 'rebeccapurple',
     fontSize: 4,
     '@media screen and (min-width: 11em)': {
       fontSize: 8,
     },
     '@media screen and (min-width: 22em)': {
+      fontSize: 16,
+      color: 'papayawhip',
+    },
+  })
+
+  const secondStyles = parser({
+    theme: {
+      ...theme,
+      breakpoints: ['9em', '8em', '7em'],
+    },
+    fontSize: [1, 2, 3],
+    color: ['primary', null, 'secondary'],
+  })
+  expect(secondStyles).toEqual({
+    color: 'rebeccapurple',
+    fontSize: 4,
+    '@media screen and (min-width: 9em)': {
+      fontSize: 8,
+    },
+    '@media screen and (min-width: 8em)': {
+      fontSize: 16,
+      color: 'papayawhip',
+    },
+  })
+
+  const thirdStyles = parser({
+    theme: {
+      ...theme,
+    },
+    fontSize: [1, 2, 3],
+    color: ['primary', null, 'secondary'],
+  })
+  expect(thirdStyles).toEqual({
+    color: 'rebeccapurple',
+    fontSize: 4,
+    '@media screen and (min-width: 40em)': {
+      fontSize: 8,
+    },
+    '@media screen and (min-width: 52em)': {
       fontSize: 16,
       color: 'papayawhip',
     },

--- a/packages/core/test/parser.js
+++ b/packages/core/test/parser.js
@@ -35,9 +35,34 @@ test('uses default breakpoints', () => {
   })
 })
 
+// Per default, we expect it to be impossible to override breakpoints
+test('does *not* use dynamically changed breakpoints', () => {
+  const styles = parser({
+    theme: { ...theme, breakpoints: ['11em', '22em', '33em'] },
+    fontSize: [1, 2, 3],
+    color: ['primary', null, 'secondary'],
+  })
+  expect(styles).toEqual({
+    color: 'rebeccapurple',
+    fontSize: 4,
+    '@media screen and (min-width: 40em)': {
+      fontSize: 8,
+    },
+    '@media screen and (min-width: 52em)': {
+      fontSize: 16,
+      color: 'papayawhip',
+    },
+  })
+})
+
+// With caching disabled, we expect it to be possible to change breakpoints
 test('uses dynamically changed breakpoints', () => {
   const firstStyles = parser({
-    theme: { ...theme, breakpoints: ['11em', '22em', '33em'] },
+    theme: {
+      ...theme,
+      breakpoints: ['11em', '22em', '33em'],
+      disableStyledSystemCache: true,
+    },
     fontSize: [1, 2, 3],
     color: ['primary', null, 'secondary'],
   })
@@ -57,6 +82,7 @@ test('uses dynamically changed breakpoints', () => {
     theme: {
       ...theme,
       breakpoints: ['9em', '8em', '7em'],
+      disableStyledSystemCache: true,
     },
     fontSize: [1, 2, 3],
     color: ['primary', null, 'secondary'],
@@ -74,19 +100,17 @@ test('uses dynamically changed breakpoints', () => {
   })
 
   const thirdStyles = parser({
-    theme: {
-      ...theme,
-    },
+    theme: theme,
     fontSize: [1, 2, 3],
     color: ['primary', null, 'secondary'],
   })
   expect(thirdStyles).toEqual({
     color: 'rebeccapurple',
     fontSize: 4,
-    '@media screen and (min-width: 40em)': {
+    '@media screen and (min-width: 9em)': {
       fontSize: 8,
     },
-    '@media screen and (min-width: 52em)': {
+    '@media screen and (min-width: 8em)': {
       fontSize: 16,
       color: 'papayawhip',
     },

--- a/packages/core/test/parser.js
+++ b/packages/core/test/parser.js
@@ -1,0 +1,55 @@
+import { system, compose } from '../src'
+
+const theme = {
+  colors: {
+    primary: 'rebeccapurple',
+    secondary: 'papayawhip',
+  },
+  fontSize: [0, 4, 8, 16],
+}
+
+const parser = system({
+  color: {
+    property: 'color',
+    scale: 'colors',
+  },
+  fontSize: true,
+})
+
+test('uses default breakpoints', () => {
+  const styles = parser({
+    theme: theme,
+    fontSize: [1, 2, 3],
+    color: ['primary', null, 'secondary'],
+  })
+  expect(styles).toEqual({
+    color: 'rebeccapurple',
+    fontSize: 4,
+    '@media screen and (min-width: 40em)': {
+      fontSize: 8,
+    },
+    '@media screen and (min-width: 52em)': {
+      fontSize: 16,
+      color: 'papayawhip',
+    },
+  })
+})
+
+test('uses dynamically provided breakpoints', () => {
+  const styles = parser({
+    theme: { ...theme, breakpoints: ['11em', '22em', '33em'] },
+    fontSize: [1, 2, 3],
+    color: ['primary', null, 'secondary'],
+  })
+  expect(styles).toEqual({
+    color: 'rebeccapurple',
+    fontSize: 4,
+    '@media screen and (min-width: 11em)': {
+      fontSize: 8,
+    },
+    '@media screen and (min-width: 22em)': {
+      fontSize: 16,
+      color: 'papayawhip',
+    },
+  })
+})


### PR DESCRIPTION
## Problem
[Starting with v5, style functions cache `theme.breakpoints`](https://github.com/styled-system/styled-system/blob/master/CHANGELOG.md#v500-2019-06-02), which
breaks nested themes with varying breakpoints.

## Possible Solution
I'm not too sure about this, so here goes a first draft:
* If you nest themes (i.e. `<ThemeProvider>`s`), and the child theme provides a new array of breakpoints, the cache should be updated.
* If you nest one more level and don't provide new values, breakpoints will fall back to the default values.

I'm not sure if this is ideal, because I don't know why the cache was implemented in the first place. If the intention was to avoid an unnecessary `get` call, then this solution won't work because it checks whether new breakpoints have been provided with `get`. I feel like I'm in over my head here, so any help is much appreciated :)

Closes #592