### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -79,4 +79,4 @@ export default {
 <Box width={{ _: 1, sm: 1, md: 1 / 2, lg: 1 / 4 }} />
 ```
 
-Read more in the [Array Props Guide](/guides/array-props).
+Read more in the [Array Props Guide](/guides/array-props.md).

--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -79,4 +79,4 @@ export default {
 <Box width={{ _: 1, sm: 1, md: 1 / 2, lg: 1 / 4 }} />
 ```
 
-Read more in the [Array Props Guide](/guides/array-props.md).
+Read more in the [Array Props Guide](docs/guides/array-props.md).


### PR DESCRIPTION
Fixed broken link to array props documentation at line: 82