### PR TITLE
Add alias for buttonStyles

### DIFF
--- a/docs/variants.md
+++ b/docs/variants.md
@@ -69,6 +69,7 @@ The built-in variants use the following props and theme keys:
 | `colorStyle`  | `colors`    | `colorStyles`               |
 | `buttonStyle` | `variant`   | `buttons` or `buttonStyles` |
 
+
 ## Custom Variants
 
 Creating custom variants allows you to extend this API in many ways.

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -63,11 +63,11 @@ The `Button` component can now use the `variant` prop to change between a primar
 
 The built-in variants use the following props and theme keys:
 
-| Function Name | Prop        | Theme Key     |
-| ------------- | ----------- | ------------- |
-| `textStyle`   | `textStyle` | `textStyles`  |
-| `colorStyle`  | `colors`    | `colorStyles` |
-| `buttonStyle` | `variant`   | `buttons`     |
+| Function Name | Prop        | Theme Key                   |
+| ------------- | ----------- | --------------------------- |
+| `textStyle`   | `textStyle` | `textStyles`                |
+| `colorStyle`  | `colors`    | `colorStyles`               |
+| `buttonStyle` | `variant`   | `buttons` or `buttonStyles` |
 
 ## Custom Variants
 

--- a/packages/variant/src/index.js
+++ b/packages/variant/src/index.js
@@ -19,6 +19,7 @@ export const variant = ({
 
 export default variant
 
-export const buttonStyle = variant({ key: 'buttons' })
+export const buttonStyle =
+  variant({ key: 'buttons' }) || variant({ key: 'buttonStyles' })
 export const textStyle = variant({ key: 'textStyles', prop: 'textStyle' })
 export const colorStyle = variant({ key: 'colorStyles', prop: 'colors' })

--- a/packages/variant/test/index.js
+++ b/packages/variant/test/index.js
@@ -77,6 +77,25 @@ test('variant can be composed', () => {
   })
 })
 
+test('buttonStyle returns the same object as buttons', () => {
+  const buttonStyles = variant({ key: 'buttonStyles' })
+  const a = buttonStyles({
+    theme: {
+      buttonStyles: {
+        primary: {
+          padding: '32px',
+          backgroundColor: 'tomato',
+        },
+      },
+    },
+    variant: 'primary',
+  })
+  expect(a).toEqual({
+    padding: '32px',
+    backgroundColor: 'tomato',
+  })
+})
+
 test('textStyle prop returns theme.textStyles object', () => {
   const a = textStyle({
     theme: {
@@ -112,4 +131,3 @@ test('colors prop returns theme.colorStyles object', () => {
     backgroundColor: '#000',
   })
 })
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,6 +2220,18 @@
   resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-2.0.4.tgz#58c9043f48a6ff3a726820829407375a71d3ca0c"
   integrity sha512-Y7D+rqEpQk4311GDrzRtO5yreILywX8JiFYWyXhB5eG8Qz7kF4KKhpta54e5GA/FGFcPF47HVKjcuATf3hqsMQ==
 
+"@styled-system/edit@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@styled-system/edit/-/edit-5.0.5.tgz#9ab7cfb0287d1c82fef372bb12f9c5bdfb2e8fd7"
+  integrity sha512-nzz3MLj9ouhLPrdlXjro3JjQBt8ruGc9JxeLP7BYlqN5vzLWYyJZ6M0A4nfk73D4QRROl9cpf2HKcZll65SARg==
+  dependencies:
+    "@emotion/core" "^10.0.10"
+    color "^3.1.0"
+    lodash.get "^4.4.2"
+    lodash.merge "^4.6.1"
+    lodash.omit "^4.5.0"
+    lodash.set "^4.3.2"
+
 "@styled-system/jsx@5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@styled-system/jsx/-/jsx-5.0.5.tgz#be4db3898103e58cf508593b0f733204763c1403"


### PR DESCRIPTION
> The built-in variants use the following props and theme keys:
>
> | Function Name | Prop        | Theme Key     |
> | ------------- | ----------- | ------------- |
> | `textStyle`   | `textStyle` | `textStyles`  |
> | `colorStyle`  | `colors`    | `colorStyles` |
> | `buttonStyle` | `variant`   | `buttons`  🤔 |


I'm curious to know why the button styles are called `buttons` instead of `buttonStyles` like the other two variants? Looks like an intentional API decision.

If it makes sense, can we add `buttonStyles` as well for consistent naming? (with backward compat)

```diff
- export const buttonStyle = variant({ key: 'buttons' })
+ export const buttonStyle = variant({ key: 'buttons' }) || variant({ key: 'buttonStyles' })
```