### PR TITLE
Declaring variants inline

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,4 +1,5 @@
 import assign from 'object-assign'
+import css from '@styled-system/css'
 
 export const merge = (a, b) => {
   let result = assign({}, a, b)
@@ -35,7 +36,10 @@ export const createParser = config => {
       if (!config[key]) continue
       const sx = config[key]
       const raw = props[key]
-      const scale = get(props.theme, sx.scale, sx.defaults)
+      const scale =
+        typeof sx.scale === 'object'
+          ? sx.scale
+          : get(props.theme, sx.scale, sx.defaults)
 
       if (typeof raw === 'object') {
         cache.breakpoints =

--- a/packages/core/test/system.js
+++ b/packages/core/test/system.js
@@ -151,6 +151,31 @@ test('gets 0 index values from theme', () => {
   expect(style).toEqual({ width: 24 })
 })
 
+test('gets values from inline scale', () => {
+  const parser = system({
+    mx: {
+      scale: [0, 5, 10, 15, 20],
+      properties: ['marginLeft', 'marginRight'],
+    },
+  })
+  expect(typeof parser).toBe('function')
+  const styles = parser({
+    mx: [2, 3, 4],
+  })
+  expect(styles).toEqual({
+    marginLeft: 10,
+    marginRight: 10,
+    '@media screen and (min-width: 40em)': {
+      marginLeft: 15,
+      marginRight: 15,
+    },
+    '@media screen and (min-width: 52em)': {
+      marginLeft: 20,
+      marginRight: 20,
+    },
+  })
+})
+
 test('ignores null values', () => {
   const parser = system({
     color: true,

--- a/packages/variant/src/index.js
+++ b/packages/variant/src/index.js
@@ -5,11 +5,12 @@ export const variant = ({
   prop = 'variant',
   // shim for v4 API
   key,
+  variants,
 }) => {
   const sx = (value, scale) => {
     return get(scale, value, null)
   }
-  sx.scale = scale || key
+  sx.scale = variants || scale || key
   const config = {
     [prop]: sx,
   }

--- a/packages/variant/test/index.js
+++ b/packages/variant/test/index.js
@@ -1,8 +1,4 @@
-import {
-  variant,
-  textStyle,
-  colorStyle,
-} from '../src'
+import { variant, textStyle, colorStyle } from '../src'
 import { system, compose } from '@styled-system/core'
 
 const theme = {
@@ -50,6 +46,54 @@ test('variant prop can be customized', () => {
   expect(a).toEqual({
     padding: '32px',
     backgroundColor: 'tomato',
+  })
+})
+
+test('variant aliases key and scale', () => {
+  const buttons = variant({ scale: 'buttonSizes', prop: 'size' })
+  const a = buttons({
+    theme: {
+      buttonSizes: [
+        {
+          fontSize: 20,
+        },
+      ],
+    },
+    size: 0,
+  })
+  expect(a).toEqual({
+    fontSize: 20,
+  })
+})
+
+test('variant styles can be declared inline', () => {
+  const buttons = variant({
+    prop: 'variant',
+    variants: {
+      primary: {
+        backgroundColor: 'tomato',
+      },
+    },
+  })
+  const buttonSizes = variant({
+    prop: 'size',
+    scale: [
+      {
+        p: 3,
+      },
+    ],
+  })
+  const a = buttons({
+    variant: 'primary',
+  })
+  const b = buttonSizes({
+    size: 0,
+  })
+  expect(a).toEqual({
+    backgroundColor: 'tomato',
+  })
+  expect(b).toEqual({
+    p: 3,
   })
 })
 
@@ -112,4 +156,3 @@ test('colors prop returns theme.colorStyles object', () => {
     backgroundColor: '#000',
   })
 })
-


### PR DESCRIPTION
Adds support for declaring variants/scales inline, rather than just in the global theme. 

This is useful when the variants are only going to be used in a single component. Declaring the variants inline helps reduce theme bloat and indirection.

Example of inline variants:

```js
const Button = styled.div`
  ${layout}
  ${variant({
    prop: 'size'
    scale: [
      { fontSize: 12, padding: 12 },
      { fontSize: 16, padding: 16 },
    ]
  })}
  ${variant({
    prop: 'type',
    variants {
      primary: { background: 'green' },
      secondary: { background: 'red'  },
    }
  })}
`
```

In hindsight, I'm not sure the introduction of another alias (`variants`) is such a good idea. I've left it in the PR in case it merits discussion.

Although this wasn't my initial objective, the implementation also provides support for writing scales inline in `system`:

```js
const myStyles = system({
  property: 'some-css-property,
  scale: [0, 1] 
});
```

If this is a feature you'd like to introduce I'd be happy to follow up with an update to the docs!