### PR TITLE
Docs: Add information about padding and margin utilities 

### DIFF
--- a/docs/guides/spacing.md
+++ b/docs/guides/spacing.md
@@ -128,9 +128,32 @@ When using the component, you can adjust margin and padding in any direction nee
 
 ```jsx
 // example usage
-<Heading mt={0} mb={4}>
+<Heading mt={0} mb={4} pl={0}>
   Hello
 </Heading>
 ```
 
 [rebass space]: https://github.com/rebassjs/space
+
+While the `space` utility is a perfect choice for most cases, it can be useful to add only margin or padding props to 
+a component. To handle those cases, Styled System provides subsets os the `space` utility: `padding` and `margin` utilities.
+
+The `padding` utility adds only padding props to a component and the `margin` utility adds only margin props. Usage of 
+the utilities are the same as the usage of `space` utility
+
+```js
+// margin utility example
+import styled from 'styled-component'
+import { margin } from 'styled-system'
+
+const Paragraph = styled.p(margin)
+```
+
+When using the component, you can adjust margin, but not padding:
+
+```jsx
+// example usage
+<Paragraph mt={0} mb={4}>
+  I have only margin props available
+</Heading>
+```

--- a/docs/table.md
+++ b/docs/table.md
@@ -27,6 +27,8 @@ import { space } from 'styled-system'
 | `px`                  | `padding-left` and `padding-right` | `space`     |
 | `py`                  | `padding-top` and `padding-bottom` | `space`     |
 
+Styled System provides subsets of `space` category: `margin` and `padding`.
+
 ## Color
 
 ```js


### PR DESCRIPTION
Adds a description of `padding` and `margin` utilities which are exported from `@styled-system/space`.

This week I had a situation when I had to provide only margins in one of my components. I couldn't find any information in the documentation. I had to read the sources to find that `space` package also exports `padding` and `margin` subsets of the `space` utility. Later I found a mention about them in the Packages section, but it was not an obvious place for me to search.

As a result, I decided to add a small section in the Spacing section with an example and a paragraph to the Reference Table section.

Let me know what do you think.