### PR TITLE
Add proof of concept for cascade overrides in space functions

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -47,6 +47,7 @@ export const createParser = config => {
       const raw = props[key]
       const scale = get(props.theme, sx.scale, sx.defaults)
 
+      let style
       if (typeof raw === 'object') {
         cache.breakpoints =
           (!isCacheDisabled && cache.breakpoints) ||
@@ -56,23 +57,27 @@ export const createParser = config => {
             null,
             ...cache.breakpoints.map(createMediaQuery),
           ]
-          styles = merge(
-            styles,
-            parseResponsiveStyle(cache.media, sx, scale, raw)
-          )
-          continue
-        }
-        if (raw !== null) {
-          styles = merge(
-            styles,
-            parseResponsiveObject(cache.breakpoints, sx, scale, raw)
-          )
+          style = parseResponsiveStyle(cache.media, sx, scale, raw)
+          // styles = merge(
+          //   styles,
+          //   parseResponsiveStyle(cache.media, sx, scale, raw)
+          // )
+        } else if (raw !== null) {
+          style = parseResponsiveObject(cache.breakpoints, sx, scale, raw)
+          // styles = merge(
+          //   styles,
+          //   parseResponsiveObject(cache.breakpoints, sx, scale, raw)
+          // )
           shouldSort = true
         }
-        continue
+      } else {
+        style = sx(raw, scale)
       }
-
-      assign(styles, sx(raw, scale))
+      if (sx.sort && sx.sort < 0) {
+        styles = merge(style, styles)
+      } else {
+        styles = merge(styles, style)
+      }
     }
 
     // sort object-based responsive styles
@@ -136,6 +141,7 @@ export const createStyleFunction = ({
   scale,
   transform = getValue,
   defaultScale,
+  sort,
 }) => {
   properties = properties || [property]
   const sx = (value, scale) => {
@@ -149,6 +155,7 @@ export const createStyleFunction = ({
   }
   sx.scale = scale
   sx.defaults = defaultScale
+  sx.sort = sort
   return sx
 }
 

--- a/packages/core/test/system.js
+++ b/packages/core/test/system.js
@@ -270,3 +270,35 @@ test('sorts media queries when responsive object values are used', () => {
     'padding',
   ])
 })
+
+test('config supports sort option', () => {
+  const parser = system({
+    m: {
+      property: 'margin',
+      sort: -1
+    },
+    ml: {
+      scale: 'space',
+      property: 'marginLeft',
+    },
+    mr: {
+      scale: 'space',
+      property: 'marginRight',
+    },
+    mx: {
+      scale: 'space',
+      properties: ['marginLeft', 'marginRight'],
+    },
+  })
+  const a = parser({ mx: 8, m: 0 })
+  const b = parser({ mr: 8, m: 0 })
+  expect(a).toEqual({
+    margin: 0,
+    marginLeft: 8,
+    marginRight: 8,
+  })
+  expect(b).toEqual({
+    margin: 0,
+    marginRight: 8,
+  })
+})

--- a/packages/space/src/index.js
+++ b/packages/space/src/index.js
@@ -27,6 +27,7 @@ configs.margin = {
     scale: 'space',
     transform: getMargin,
     defaultScale: defaults.space,
+    sort: -1,
   },
   marginTop: {
     property: 'marginTop',
@@ -57,12 +58,14 @@ configs.margin = {
     scale: 'space',
     transform: getMargin,
     defaultScale: defaults.space,
+    sort: -1,
   },
   marginY: {
     properties: ['marginTop', 'marginBottom'],
     scale: 'space',
     transform: getMargin,
     defaultScale: defaults.space,
+    sort: -1,
   },
 }
 configs.margin.m = configs.margin.margin
@@ -78,6 +81,7 @@ configs.padding = {
     property: 'padding',
     scale: 'space',
     defaultScale: defaults.space,
+    sort: -1,
   },
   paddingTop: {
     property: 'paddingTop',
@@ -103,11 +107,13 @@ configs.padding = {
     properties: ['paddingLeft', 'paddingRight'],
     scale: 'space',
     defaultScale: defaults.space,
+    sort: -1,
   },
   paddingY: {
     properties: ['paddingTop', 'paddingBottom'],
     scale: 'space',
     defaultScale: defaults.space,
+    sort: -1,
   },
 }
 configs.padding.p = configs.padding.padding

--- a/packages/space/test/index.js
+++ b/packages/space/test/index.js
@@ -100,36 +100,36 @@ test('pl prop sets paddingLeft 0', () => {
   expect(styles).toEqual({ paddingLeft: 0 })
 })
 
-test('px prop overrides pl prop', () => {
+test('pl prop overrides px prop', () => {
   const styles = space({
     pl: 1,
     px: 2,
   })
-  expect(styles).toEqual({ paddingLeft: 8, paddingRight: 8 })
+  expect(styles).toEqual({ paddingLeft: 4, paddingRight: 8 })
 })
 
-test('py prop overrides pb prop', () => {
+test('pb prop overrides py prop', () => {
   const styles = space({
     pb: 1,
     py: 2,
   })
-  expect(styles).toEqual({ paddingTop: 8, paddingBottom: 8 })
+  expect(styles).toEqual({ paddingTop: 8, paddingBottom: 4 })
 })
 
-test('mx prop overrides mr prop', () => {
+test('mr prop overrides mx prop', () => {
   const styles = space({
     mr: 1,
     mx: 2,
   })
-  expect(styles).toEqual({ marginLeft: 8, marginRight: 8 })
+  expect(styles).toEqual({ marginLeft: 8, marginRight: 4 })
 })
 
-test('my prop overrides mt prop', () => {
+test('mt prop overrides my prop', () => {
   const styles = space({
     mt: 1,
     my: 2,
   })
-  expect(styles).toEqual({ marginTop: 8, marginBottom: 8 })
+  expect(styles).toEqual({ marginTop: 4, marginBottom: 8 })
 })
 
 test('margin overrides m prop', () => {


### PR DESCRIPTION
- Adds the ability to sort CSS properties in `system` config
- Sorts `margin`, `padding`, `marginX`, `marginY`, `paddingX`, and `paddingY` shorthands first to allow normal CSS properties to take precedence