### PR TITLE
Corrects broken 'edit on github' links

### DIFF
--- a/docs/src/edit-link.js
+++ b/docs/src/edit-link.js
@@ -2,27 +2,51 @@ import React from 'react'
 import { Location } from '@reach/router'
 import { css } from 'theme-ui'
 
-const base = 'https://github.com/styled-system/styled-system/edit/master/docs'
+// Removes preceding and trailing slashes
+const parsePage = string => string.replace(/\/+$/, '').substr(1)
 
-const getHREF = location => {
-  if (location.pathname === '/') return base + '/getting-started.md'
-  return base + location.pathname.replace(/\/+$/, '') + '.md'
+const base = 'https://github.com/styled-system/styled-system/edit/master'
+
+// Pages that don't reference the default /docs/{page}.md
+const custom = {
+  css: '/packages/css/README.md',
+  demo: '/docs/src/pages/demo.js',
+}
+
+// Don't display the edit link on these pages:
+const ignore = ['babel-plugin']
+
+const getHREF = page => {
+  if (custom[page]) return base + custom[page]
+  return `${base}/docs/${page}.md`
 }
 
 export default () => (
   <Location>
-    {({ location }) => (
-      <a
-        href={getHREF(location)}
-        css={css({
-          display: 'inline-block',
-          color: 'inherit',
-          fontSize: 1,
-          my: 4,
-        })}
-      >
-        Edit this page on GitHub
-      </a>
-    )}
+    {({ location }) => {
+      const page = parsePage(location.pathname)
+
+      if (ignore.includes(page)) {
+        return null
+      }
+
+      return (
+        <a
+          href={
+            location.pathname === '/'
+              ? base + '/docs/getting-started.md'
+              : getHREF(page)
+          }
+          css={css({
+            display: 'inline-block',
+            color: 'inherit',
+            fontSize: 1,
+            my: 4,
+          })}
+        >
+          Edit this page on GitHub
+        </a>
+      )
+    }}
   </Location>
 )


### PR DESCRIPTION
I also added the ability to hide the edit link on certain pages, as I don't think the babel-plugin repo is public?