### PR TITLE
Component variants with theme-based values

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -480,18 +480,27 @@ The function takes two arguments: `(value, scale)`, where `value` is the raw pro
 
 ## Variant
 
-Creates a custom style utility that maps props to style objects in a theme.
+Creates a custom style utility to apply complex styles based on a single prop.
 
 ```js
 import styled from 'styled-components'
 import { variant } from 'styled-system'
 
-const cardStyle = variant({
-  key: 'cards',
-})
-
 const Card = styled.div`
-  ${cardStyle}
+  ${variant({
+    variants: {
+      normal: {
+        p: 2,
+        boxShadow: 'default',
+        borderRadius: 2,
+      },
+      large: {
+        p: 3,
+        boxShadow: 'large',
+        borderRadius: 4,
+      },
+    }
+  })}
 `
 Card.defaultProps = {
   variant: 'normal',
@@ -499,42 +508,9 @@ Card.defaultProps = {
 // <Card variant='large' />
 ```
 
-## Variants
+## Legacy Variants
 
-The variant style utilities allow you to define reusable style objects in your theme for things like text styles and color combinations.
-
-**NOTE:** the objects defined in the theme are _CSS style_ objects, not component _props_. Styled system props **will not** work here to avoid conflating CSS style objects with component props.
-
-```js
-// example theme
-const theme = {
-  textStyles: {
-    caps: {
-      textTransform: 'uppercase',
-      letterSpacing: '0.2em',
-    },
-  },
-  colorStyles: {
-    warning: {
-      color: 'black',
-      backgroundColor: 'orange',
-    },
-    error: {
-      color: 'white',
-      backgroundColor: 'red',
-    },
-  },
-  buttons: {
-    primary: {
-      color: 'white',
-      backgroundColor: 'blue',
-      '&:hover': {
-        backgroundColor: 'black',
-      },
-    },
-  },
-}
-```
+The legacy variants require styles to be defined in the theme object and do *not* use `@styled-system/css` for transformation.
 
 ```js
 import { textStyle, colorStyle, buttonStyle } from 'styled-system'

--- a/docs/src/sidebar.mdx
+++ b/docs/src/sidebar.mdx
@@ -22,5 +22,4 @@
   - [Migrating to v5](/guides/migrating)
 - [Demo](/demo)
 - [CSS](/css)
-- [Babel Plugin](/babel-plugin)
 - [GitHub](https://github.com/styled-system/styled-system)

--- a/docs/table.md
+++ b/docs/table.md
@@ -248,6 +248,8 @@ import { shadow } from 'styled-system'
 
 ## Variants
 
+**Note**: The prefered API for [variants](/variants) has changed. The following is a reference for legacy variant APIs.
+
 ```js
 import { textStyle, colorStyle, buttonStyle } from 'styled-system'
 // or `import { textStyle, colorStyle, buttonStyle } from '@styled-system/variant'`

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -1,12 +1,12 @@
 # Variants
 
-Use the variant APII to apply complex styles to a component based on a single prop.
+Use the variant API to apply complex styles to a component based on a single prop.
 This can be a handy way to support slight stylistic variations in button or typography components.
 
-Import the variant function and pass in variant style objects in your component definition.
+Import the variant function and pass variant style objects in your component definition.
 When defining variants inline, you can use Styled System like syntax to pick up values from your theme.
 
-**Note**: Inline variants is a new feature in `v5.1.0`, and it uses [@styled-system/css][].
+**Note**: Inline variants is a new feature in `v5.1.0`, which uses [@styled-system/css][].
 
 ```js
 // example Button with variants
@@ -47,7 +47,7 @@ If you'd like to use a custom prop name other than `variant`, use the `prop` opt
 ```js
 const Text = styled('div')(
   variant({
-    prop: 'sizes',
+    prop: 'size',
     variants: {
       big: {
         fontSize: 4,
@@ -60,6 +60,8 @@ const Text = styled('div')(
     }
   })
 )
+
+// <Text size='big' />
 ```
 
 ## Themeable Variants

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -1,56 +1,35 @@
 # Variants
 
-Variants can be useful for applying complex styles to a component based on a single prop.
-Styled System includes built-in variants for `textStyle`, `colorStyle`, and `buttonStyle`.
+Use the variant APII to apply complex styles to a component based on a single prop.
+This can be a handy way to support slight stylistic variations in button or typography components.
 
-To use variants, first define styles in your `theme` object.
+Import the variant function and pass in variant style objects in your component definition.
+When defining variants inline, you can use Styled System like syntax to pick up values from your theme.
 
-```js
-// example theme with variants
-import colors from './colors'
-
-export default {
-  ...colors,
-  textStyles: {
-    caps: {
-      textTransform: 'uppercase',
-      letterSpacing: '0.1em',
-    },
-  },
-  colorStyles: {
-    inverted: {
-      color: colors.background,
-      backgroundColor: colors.text,
-    },
-  },
-  buttons: {
-    primary: {
-      color: colors.white,
-      backgroundColor: colors.primary,
-    },
-    secondary: {
-      color: colors.text,
-      backgroundColor: colors.secondary,
-    },
-  },
-}
-```
-
-**NOTE:** the objects defined in the theme are _CSS style_ objects, not component _props_. Styled system props **will not** work here to avoid conflating CSS style objects with component props.
-
-Next, add variant utilities to your components.
+**Note**: Inline variants is a new feature in `v5.1.0`, and it uses [@styled-system/css][].
 
 ```js
 // example Button with variants
 import styled from 'styled-components'
-import { buttonStyle } from 'styled-system'
+import { variant } from 'styled-system'
 
 const Button = styled('button')(
   {
     appearance: 'none',
     fontFamily: 'inherit',
   },
-  buttonStyle
+  variant({
+    variants: {
+      primary: {
+        color: 'white',
+        bg: 'primary',
+      },
+      secondary: {
+        color: 'white',
+        bg: 'secondary',
+      },
+    }
+  })
 )
 ```
 
@@ -61,6 +40,86 @@ The `Button` component can now use the `variant` prop to change between a primar
 <Button variant='secondary'>Secondary</Button>
 ```
 
+## Custom Prop Name
+
+If you'd like to use a custom prop name other than `variant`, use the `prop` option.
+
+```js
+const Text = styled('div')(
+  variant({
+    prop: 'sizes',
+    variants: {
+      big: {
+        fontSize: 4,
+        lineHeight: 'heading',
+      },
+      small: {
+        fontSize: 1,
+        lineHeight: 'body',
+      },
+    }
+  })
+)
+```
+
+## Themeable Variants
+
+If you'd like to enable theming of variants from the global theme object, use the `scale` option to define the theme key to use for variants.
+
+```js
+const Button = styled('button')(
+  variant({
+    scale: 'buttons',
+    variants: {
+      primary: {
+        color: 'white',
+        bg: 'primary',
+      },
+      secondary: {
+        color: 'white',
+        bg: 'secondary',
+      },
+    },
+  })
+)
+```
+
+With the `scale` option above, the `theme.buttons` object can be used to overrided variants defined in the component.
+
+```js
+// example theme
+export default {
+  // base theme values...
+  // custom button variants
+  buttons: {
+    primary: {
+      color: 'white',
+      bg: 'red',
+    },
+    secondary: {
+      color: 'white',
+      bg: 'tomato',
+    },
+  }
+}
+```
+
+## Legacy API
+
+To continue using the previous variant API,
+without transforming style objects based on the theme,
+omit the `variants` option.
+
+```js
+// legacy API
+variant({
+  prop: 'size',
+  scale: 'typeSizes',
+})
+```
+
+### Built-in Variants
+
 The built-in variants use the following props and theme keys:
 
 | Function Name | Prop        | Theme Key     |
@@ -69,21 +128,5 @@ The built-in variants use the following props and theme keys:
 | `colorStyle`  | `colors`    | `colorStyles` |
 | `buttonStyle` | `variant`   | `buttons`     |
 
-## Custom Variants
+[@styled-system/css]: /css
 
-Creating custom variants allows you to extend this API in many ways.
-To create a custom variant, import the `variant` utility to create a style prop function.
-
-```js
-import styled from 'styled-components'
-import { variant } from 'styled-system'
-
-const buttonSizes = variant({
-  // theme key for variant definitions
-  scale: 'buttonSizes',
-  // component prop
-  prop: 'size',
-})
-
-const Button = styled('button')(buttonSizes)
-```

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -58,21 +58,21 @@ export const createParser = config => {
           ]
           styles = merge(
             styles,
-            parseResponsiveStyle(cache.media, sx, scale, raw)
+            parseResponsiveStyle(cache.media, sx, scale, raw, props)
           )
           continue
         }
         if (raw !== null) {
           styles = merge(
             styles,
-            parseResponsiveObject(cache.breakpoints, sx, scale, raw)
+            parseResponsiveObject(cache.breakpoints, sx, scale, raw, props)
           )
           shouldSort = true
         }
         continue
       }
 
-      assign(styles, sx(raw, scale))
+      assign(styles, sx(raw, scale, props))
     }
 
     // sort object-based responsive styles
@@ -96,11 +96,11 @@ export const createParser = config => {
   return parse
 }
 
-const parseResponsiveStyle = (mediaQueries, sx, scale, raw) => {
+const parseResponsiveStyle = (mediaQueries, sx, scale, raw, _props) => {
   let styles = {}
   raw.slice(0, mediaQueries.length).forEach((value, i) => {
     const media = mediaQueries[i]
-    const style = sx(value, scale)
+    const style = sx(value, scale, _props)
     if (!media) {
       assign(styles, style)
     } else {
@@ -112,12 +112,12 @@ const parseResponsiveStyle = (mediaQueries, sx, scale, raw) => {
   return styles
 }
 
-const parseResponsiveObject = (breakpoints, sx, scale, raw) => {
+const parseResponsiveObject = (breakpoints, sx, scale, raw, _props) => {
   let styles = {}
   for (let key in raw) {
     const breakpoint = breakpoints[key]
     const value = raw[key]
-    const style = sx(value, scale)
+    const style = sx(value, scale, _props)
     if (!breakpoint) {
       assign(styles, style)
     } else {

--- a/packages/variant/README.md
+++ b/packages/variant/README.md
@@ -11,24 +11,6 @@ import variant from '@styled-system/variant'
 
 const Button = styled('button')(
   variant({
-    prop: 'variant',
-    scale: 'buttons', // key for `theme.buttons`
-  })
-)
-
-// <Button variant='primary' />
-// <Button variant='secondary' />
-```
-
-## Component Variants
-
-```js
-import styled from 'styled-components'
-import { componentVariant } from '@styled-system/variant'
-
-const Button = styled('button')(
-  componentVariant({
-    prop: 'variant',
     variants: {
       primary: {
         color: 'white',
@@ -43,11 +25,19 @@ const Button = styled('button')(
         ':hover': {
           bg: 'black',
         }
-      }
+      },
     }
   })
 )
 
 // <Button variant='primary' />
+// <Button variant='secondary' />
 ```
 
+## Options
+
+- `variants`: object of theme-aware variant styles with user-defined shape
+- `prop`: (default `variant`) custom prop name for variant
+- `scale`: optional theme key for adding variants to the theme object
+
+MIT License

--- a/packages/variant/README.md
+++ b/packages/variant/README.md
@@ -1,0 +1,53 @@
+
+# @styled-system/variant
+
+Read the docs: https://styled-system.com/variants
+
+## Usage
+
+```js
+import styled from 'styled-components'
+import variant from '@styled-system/variant'
+
+const Button = styled('button')(
+  variant({
+    prop: 'variant',
+    scale: 'buttons', // key for `theme.buttons`
+  })
+)
+
+// <Button variant='primary' />
+// <Button variant='secondary' />
+```
+
+## Component Variants
+
+```js
+import styled from 'styled-components'
+import { componentVariant } from '@styled-system/variant'
+
+const Button = styled('button')(
+  componentVariant({
+    prop: 'variant',
+    variants: {
+      primary: {
+        color: 'white',
+        bg: 'primary',
+        ':hover': {
+          bg: 'black',
+        }
+      },
+      secondary: {
+        color: 'white',
+        bg: 'secondary',
+        ':hover': {
+          bg: 'black',
+        }
+      }
+    }
+  })
+)
+
+// <Button variant='primary' />
+```
+

--- a/packages/variant/package.json
+++ b/packages/variant/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@styled-system/core": "^5.0.21",
-    "@styled-system/css": "*"
+    "@styled-system/css": "^5.0.23"
   },
   "gitHead": "a6feb6009c58f2eb68f0c3120c5672f6cb54294f",
   "publishConfig": {

--- a/packages/variant/package.json
+++ b/packages/variant/package.json
@@ -6,7 +6,8 @@
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@styled-system/core": "^5.0.21"
+    "@styled-system/core": "^5.0.21",
+    "@styled-system/css": "*"
   },
   "gitHead": "a6feb6009c58f2eb68f0c3120c5672f6cb54294f",
   "publishConfig": {

--- a/packages/variant/src/index.js
+++ b/packages/variant/src/index.js
@@ -30,12 +30,26 @@ export const componentVariant = ({
   variants = {},
   scale,
 }) => {
+  /* create parser approach
+   * todo: needs access to theme or props
+    const sx = (value, scale, props) => {
+      return css(get(scale, value, null))(props.theme)
+    }
+    sx.scale = scale
+    sx.defaults = variants
+    const config = {
+      [prop]: sx
+    }
+    const parser = createParser(config)
+    return parser
+  */
   const parser = props => {
     const name = props[prop]
-    if (!name) return null
-    const style = get(variants, name)
+    if (!name) return {}
+    const style = get(props.theme, `${scale}.${name}`,
+      get(variants, name)
+    )
     return css(style)(props.theme)
   }
-
   return parser
 }

--- a/packages/variant/src/index.js
+++ b/packages/variant/src/index.js
@@ -4,13 +4,19 @@ import css from '@styled-system/css'
 export const variant = ({
   scale,
   prop = 'variant',
+  // enables new api
+  variants = {},
   // shim for v4 API
   key,
 }) => {
-  const sx = (value, scale) => {
-    return get(scale, value, null)
+  let sx
+  if (Object.keys(variants).length) {
+    sx = (value, scale, props) => css(get(scale, value, null))(props.theme)
+  } else {
+    sx = (value, scale) => get(scale, value, null)
   }
   sx.scale = scale || key
+  sx.defaults = variants
   const config = {
     [prop]: sx,
   }
@@ -23,33 +29,3 @@ export default variant
 export const buttonStyle = variant({ key: 'buttons' })
 export const textStyle = variant({ key: 'textStyles', prop: 'textStyle' })
 export const colorStyle = variant({ key: 'colorStyles', prop: 'colors' })
-
-// new api
-export const componentVariant = ({
-  prop = 'variant',
-  variants = {},
-  scale,
-}) => {
-  /* create parser approach
-   * todo: needs access to theme or props
-    const sx = (value, scale, props) => {
-      return css(get(scale, value, null))(props.theme)
-    }
-    sx.scale = scale
-    sx.defaults = variants
-    const config = {
-      [prop]: sx
-    }
-    const parser = createParser(config)
-    return parser
-  */
-  const parser = props => {
-    const name = props[prop]
-    if (!name) return {}
-    const style = get(props.theme, `${scale}.${name}`,
-      get(variants, name)
-    )
-    return css(style)(props.theme)
-  }
-  return parser
-}

--- a/packages/variant/src/index.js
+++ b/packages/variant/src/index.js
@@ -1,4 +1,5 @@
 import { get, createParser } from '@styled-system/core'
+import css from '@styled-system/css'
 
 export const variant = ({
   scale,
@@ -22,3 +23,19 @@ export default variant
 export const buttonStyle = variant({ key: 'buttons' })
 export const textStyle = variant({ key: 'textStyles', prop: 'textStyle' })
 export const colorStyle = variant({ key: 'colorStyles', prop: 'colors' })
+
+// new api
+export const componentVariant = ({
+  prop = 'variant',
+  variants = {},
+  scale,
+}) => {
+  const parser = props => {
+    const name = props[prop]
+    if (!name) return null
+    const style = get(variants, name)
+    return css(style)(props.theme)
+  }
+
+  return parser
+}

--- a/packages/variant/test/index.js
+++ b/packages/variant/test/index.js
@@ -2,7 +2,6 @@ import {
   variant,
   textStyle,
   colorStyle,
-  componentVariant,
 } from '../src'
 import { system, compose } from '@styled-system/core'
 
@@ -116,7 +115,7 @@ test('colors prop returns theme.colorStyles object', () => {
 
 describe('component variant', () => {
   test('returns a variant defined inline', () => {
-    const comp = componentVariant({
+    const comp = variant({
       variants: {
         primary: {
           color: 'black',
@@ -141,7 +140,7 @@ describe('component variant', () => {
   })
 
   test('returns theme-aware styles', () => {
-    const comp = componentVariant({
+    const comp = variant({
       variants: {
         primary: {
           p: 3,
@@ -168,7 +167,7 @@ describe('component variant', () => {
   })
 
   test('can use a custom prop name', () => {
-    const comp = componentVariant({
+    const comp = variant({
       prop: 'size',
       variants: {
         big: {
@@ -187,7 +186,11 @@ describe('component variant', () => {
   })
 
   test('does not throw when no variants are found', () => {
-    const comp = componentVariant({})
+    const comp = variant({
+      variants: {
+        beep: {}
+      }
+    })
     let style
     expect(() => {
       style = comp({ variant: 'beep' })
@@ -196,18 +199,18 @@ describe('component variant', () => {
   })
 
   test('returns empty object when no prop is provided', () => {
-    const comp = componentVariant({})
+    const comp = variant({
+      variants: {
+        beep: {}
+      }
+    })
     const style = comp({})
     expect(style).toEqual({})
   })
 
-  // todo: requires update to core createParser
-  test.skip('can be composed with other style props', () => {
-    // variant.config
-    // config.variant.scale // key
-    // config.variant.defaults
+  test('can be composed with other style props', () => {
     const parser = compose(
-      componentVariant({
+      variant({
         variants: {
           tomato: {
             color: 'tomato',
@@ -219,22 +222,28 @@ describe('component variant', () => {
       color,
       fontSize
     )
-    const style = parser({
+    const a = parser({
+      variant: 'tomato',
+    })
+    const b = parser({
       variant: 'tomato',
       color: 'blue',
       fontSize: 32,
     })
-    expect(style).toEqual({
+    expect(a).toEqual({
+      color: 'tomato',
+      fontSize: 20,
+      fontWeight: 'bold',
+    })
+    expect(b).toEqual({
       color: 'blue',
       fontSize: 32,
       fontWeight: 'bold',
     })
   })
 
-  test.todo('can be used with other style props')
-
   test('theme-based variants override local variants', () => {
-    const comp = componentVariant({
+    const comp = variant({
       variants: {
         primary: {
           color: 'white',
@@ -259,7 +268,4 @@ describe('component variant', () => {
       backgroundColor: 'cyan',
     })
   })
-
-  // OR should iit work this way??
-  test.todo('falls back to variants defined in theme')
 })

--- a/packages/variant/test/index.js
+++ b/packages/variant/test/index.js
@@ -2,6 +2,7 @@ import {
   variant,
   textStyle,
   colorStyle,
+  componentVariant,
 } from '../src'
 import { system, compose } from '@styled-system/core'
 
@@ -113,3 +114,63 @@ test('colors prop returns theme.colorStyles object', () => {
   })
 })
 
+describe('component variant', () => {
+  test('returns a variant defined inline', () => {
+    const comp = componentVariant({
+      variants: {
+        primary: {
+          color: 'black',
+          bg: 'tomato',
+        },
+        secondary: {
+          color: 'white',
+          bg: 'purple',
+        },
+      }
+    })
+    const primary = comp({ variant: 'primary' })
+    const secondary = comp({ variant: 'secondary' })
+    expect(primary).toEqual({
+      color: 'black',
+      backgroundColor: 'tomato',
+    })
+    expect(secondary).toEqual({
+      color: 'white',
+      backgroundColor: 'purple',
+    })
+  })
+
+  test('returns theme-aware styles', () => {
+    const comp = componentVariant({
+      variants: {
+        primary: {
+          p: 3,
+          fontSize: 1,
+          color: 'white',
+          bg: 'primary',
+        },
+      }
+    })
+    const style = comp({
+      variant: 'primary',
+      theme: {
+        colors: {
+          primary: '#07c',
+        }
+      }
+    })
+    expect(style).toEqual({
+      padding: 16,
+      fontSize: 14,
+      color: 'white',
+      backgroundColor: '#07c',
+    })
+  })
+
+  test.todo('can be used with other style props')
+
+  // which one?
+  test.todo('falls back to variants defined in theme')
+  // OR
+  test.todo('theme-based variants override local variants')
+})

--- a/packages/variant/test/index.js
+++ b/packages/variant/test/index.js
@@ -167,10 +167,99 @@ describe('component variant', () => {
     })
   })
 
+  test('can use a custom prop name', () => {
+    const comp = componentVariant({
+      prop: 'size',
+      variants: {
+        big: {
+          fontSize: 32,
+          fontWeight: 900,
+          lineHeight: 1.25,
+        },
+      }
+    })
+    const style = comp({ size: 'big' })
+    expect(style).toEqual({
+      fontSize: 32,
+      fontWeight: 900,
+      lineHeight: 1.25,
+    })
+  })
+
+  test('does not throw when no variants are found', () => {
+    const comp = componentVariant({})
+    let style
+    expect(() => {
+      style = comp({ variant: 'beep' })
+    }).not.toThrow()
+    expect(style).toEqual({})
+  })
+
+  test('returns empty object when no prop is provided', () => {
+    const comp = componentVariant({})
+    const style = comp({})
+    expect(style).toEqual({})
+  })
+
+  // todo: requires update to core createParser
+  test.skip('can be composed with other style props', () => {
+    // variant.config
+    // config.variant.scale // key
+    // config.variant.defaults
+    const parser = compose(
+      componentVariant({
+        variants: {
+          tomato: {
+            color: 'tomato',
+            fontSize: 20,
+            fontWeight: 'bold',
+          }
+        }
+      }),
+      color,
+      fontSize
+    )
+    const style = parser({
+      variant: 'tomato',
+      color: 'blue',
+      fontSize: 32,
+    })
+    expect(style).toEqual({
+      color: 'blue',
+      fontSize: 32,
+      fontWeight: 'bold',
+    })
+  })
+
   test.todo('can be used with other style props')
 
-  // which one?
+  test('theme-based variants override local variants', () => {
+    const comp = componentVariant({
+      variants: {
+        primary: {
+          color: 'white',
+          bg: 'blue',
+        }
+      },
+      scale: 'buttons',
+    })
+    const style = comp({
+      variant: 'primary',
+      theme: {
+        buttons: {
+          primary: {
+            color: 'black',
+            bg: 'cyan',
+          }
+        }
+      }
+    })
+    expect(style).toEqual({
+      color: 'black',
+      backgroundColor: 'cyan',
+    })
+  })
+
+  // OR should iit work this way??
   test.todo('falls back to variants defined in theme')
-  // OR
-  test.todo('theme-based variants override local variants')
 })


### PR DESCRIPTION
Fixes #582 
Supersedes: #583 

- Adds support for defining inline variants in a component definition
- These variants use `@styled-system/css` to access values from the theme object
- Variant overrides can *optionally* be provided in the theme object
- The current `variant` API is still supported in a non-breaking way, it can be enabled by omitting the new `variants` option