### PR TITLE
css: add outlineColor theme scale

### DIFF
--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -101,6 +101,7 @@ const scales = {
   borderRightWidth: 'borderWidths',
   borderRightColor: 'colors',
   borderRightStyle: 'borderStyles',
+  outlineColor: 'colors',
   boxShadow: 'shadows',
   textShadow: 'shadows',
   zIndex: 'zIndices',

--- a/packages/css/test/index.js
+++ b/packages/css/test/index.js
@@ -397,3 +397,12 @@ test('multiples are transformed', () => {
     height: 16,
   })
 })
+
+test('returns outline color from theme', () => {
+  const result = css({
+    outlineColor: 'primary',
+  })(theme)
+  expect(result).toEqual({
+    outlineColor: 'tomato'
+  })
+})


### PR DESCRIPTION
Add ability to reference color values from theme when using outlineColor
Relevant issue: https://github.com/rebassjs/rebass/issues/735