### PR TITLE
Officially pass props as argument to `transform`

### DIFF
--- a/docs/custom-props.md
+++ b/docs/custom-props.md
@@ -45,7 +45,7 @@ Each key can define the following:
 
 By default, Styled System will return either a value from the theme, based on a key, or the raw value.
 To change how a style prop value is transformed, provide a custom `transform` function.
-The function takes two arguments: `(value, scale)`, where `value` is the raw prop value, and `scale` is a theme scale object or array.
+The function takes three arguments: `(value, scale, props)`, where `value` is the raw prop value, and `scale` is a theme scale object or array, and `props` are all the props passed to the component.
 
 ### Shortcut definition
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -15,10 +15,12 @@ export const merge = (a, b) => {
 const sort = obj => {
   const next = {}
   Object.keys(obj)
-    .sort((a, b) => a.localeCompare(b, undefined, {
-      numeric: true,
-      sensitivity: 'base',
-    }))
+    .sort((a, b) =>
+      a.localeCompare(b, undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      })
+    )
     .forEach(key => {
       next[key] = obj[key]
     })
@@ -101,11 +103,11 @@ export const createParser = config => {
   return parse
 }
 
-const parseResponsiveStyle = (mediaQueries, sx, scale, raw, _props) => {
+const parseResponsiveStyle = (mediaQueries, sx, scale, raw, props) => {
   let styles = {}
   raw.slice(0, mediaQueries.length).forEach((value, i) => {
     const media = mediaQueries[i]
-    const style = sx(value, scale, _props)
+    const style = sx(value, scale, props)
     if (!media) {
       assign(styles, style)
     } else {
@@ -117,12 +119,12 @@ const parseResponsiveStyle = (mediaQueries, sx, scale, raw, _props) => {
   return styles
 }
 
-const parseResponsiveObject = (breakpoints, sx, scale, raw, _props) => {
+const parseResponsiveObject = (breakpoints, sx, scale, raw, props) => {
   let styles = {}
   for (let key in raw) {
     const breakpoint = breakpoints[key]
     const value = raw[key]
-    const style = sx(value, scale, _props)
+    const style = sx(value, scale, props)
     if (!breakpoint) {
       assign(styles, style)
     } else {
@@ -143,9 +145,9 @@ export const createStyleFunction = ({
   defaultScale,
 }) => {
   properties = properties || [property]
-  const sx = (value, scale, _props) => {
+  const sx = (value, scale, props) => {
     const result = {}
-    const n = transform(value, scale, _props)
+    const n = transform(value, scale, props)
     if (n === null) return
     properties.forEach(prop => {
       result[prop] = n


### PR DESCRIPTION
I realize this is a totally superficial change because the `transform` function currently already does pass in `props` as the third parameter (and seems to be somewhat supported based on #700), but it's not "officially" supported -- meaning it's not documented at all, and it's using a prefixed underscore that typically indicates it's a "private" variable.

Is there a particular reason for this? I would love to see this be "officially" supported because it would be super-useful. But I'm not sure if this was done intentionally. So I figured I'd just put up a PR and see if it's something that might be considered.

And while you can certainly use it as it stand right now, there's 2 problems:

1. There's no guarantee this won't change in the future without notice.
2. It means it's not included in the TypeScript typings. So it causes a lot of problems for folks using TypeScript. (If this gets in I'll also put up a PR for changes at DefinitelyTyped).