### PR TITLE
Merging variant and theme-based objects

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -39,7 +39,7 @@ export const get = (obj, key, def, p, undef) => {
   return obj === undef ? def : obj
 }
 
-export const createParser = config => {
+export const createParser = (config, getScale = get) => {
   const cache = {}
   const parse = props => {
     let styles = {}
@@ -50,7 +50,7 @@ export const createParser = config => {
       if (!config[key]) continue
       const sx = config[key]
       const raw = props[key]
-      const scale = get(props.theme, sx.scale, sx.defaults)
+      const scale = getScale(props.theme, sx.scale, sx.defaults)
 
       if (typeof raw === 'object') {
         cache.breakpoints =
@@ -94,7 +94,7 @@ export const createParser = config => {
   const keys = Object.keys(config).filter(k => k !== 'config')
   if (keys.length > 1) {
     keys.forEach(key => {
-      parse[key] = createParser({ [key]: config[key] })
+      parse[key] = createParser({ [key]: config[key] }, getScale)
     })
   }
 

--- a/packages/variant/src/index.js
+++ b/packages/variant/src/index.js
@@ -1,6 +1,11 @@
 import { get, createParser } from '@styled-system/core'
 import css from '@styled-system/css'
 
+const getMergedScale = (theme, scale, variants = {}) => {
+  const themeVariants = get(theme, scale) || {};
+  return {...variants, ...themeVariants};
+}
+
 export const variant = ({
   scale,
   prop = 'variant',
@@ -20,7 +25,7 @@ export const variant = ({
   const config = {
     [prop]: sx,
   }
-  const parser = createParser(config)
+  const parser = createParser(config, getMergedScale)
   return parser
 }
 

--- a/packages/variant/test/index.js
+++ b/packages/variant/test/index.js
@@ -268,4 +268,50 @@ describe('component variant', () => {
       backgroundColor: 'cyan',
     })
   })
+
+  test('theme-based variants extends local variants', () => {
+    const comp = variant({
+      variants: {
+        primary: {
+          color: 'white',
+          bg: 'blue',
+        },
+        secondary: {
+          color: 'white',
+          bg: 'green',
+        }
+      },
+      scale: 'buttons',
+    })
+    const a = comp({
+      variant: 'primary',
+      theme: {
+        buttons: {
+          primary: {
+            color: 'black',
+            bg: 'cyan',
+          }
+        }
+      }
+    })
+    const b = comp({
+      variant: 'secondary',
+      theme: {
+        buttons: {
+          primary: {
+            color: 'black',
+            bg: 'cyan',
+          }
+        }
+      }
+    })
+    expect(a).toEqual({
+      color: 'black',
+      backgroundColor: 'cyan',
+    })
+    expect(b).toEqual({
+      color: 'white',
+      backgroundColor: 'green',
+    })
+  });
 })


### PR DESCRIPTION
This PR tries to solves for #706 . 

If a variant styles are defined in both theme object and as inline to `variant()` function, variants in the theme object will be the base and it will take the remaining variants from inline variants.

This makes it possible to override only few variants in our custom theme object and still use all the variants from inline variants and theme object without having to redefine everything in our theme object.

Please look at the test case added in this PR to understand the functionality better.