### PR TITLE
[Docs] Add color coding to example code

### DIFF
--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -118,7 +118,7 @@ const baseColors = {
 
 This base color object can then be mapped to a color abstraction.
 
-```
+```js
 // example color abstraction
 const colors = {
   text: baseColors.black,


### PR DESCRIPTION
Adds Javascript color coding to code example in theming.md for easier reading, like in previous code block.