### PR TITLE
[Docs] Small typos in array-scales.md

### DIFF
--- a/docs/guides/array-scales.md
+++ b/docs/guides/array-scales.md
@@ -10,8 +10,8 @@ The first question that comes up with approaches like this is always, "what if..
 In software development, some people think that duplication is better than the wrong abstraction.
 I tend to agree with this sentiment.
 Instead of asking _what if_, I encourage you to try the Styled System approach in a smaller application and see if the benefits
-of the constraints with this approach outweight the limitations.
-When using Styled System on a multidisciplinary team, you'll want to make sure you're entire team, including designers,
+of the constraints with this approach outweigh the limitations.
+When using Styled System on a multidisciplinary team, you'll want to make sure your entire team, including designers,
 are on board, but from my experience, many designers will want to work with constraints like the ones
 encouraged here.
 


### PR DESCRIPTION
Fixes some very small typos in the Array Scales docs.