### PR TITLE
Support theme keys containing a dot

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -32,6 +32,7 @@ const createMediaQuery = n => `@media screen and (min-width: ${n})`
 const getValue = (n, scale) => get(scale, n, n)
 
 export const get = (obj, key, def, p, undef) => {
+  if (obj[key] !== undef) return obj[key]
   key = key && key.split ? key.split('.') : [key]
   for (p = 0; p < key.length; p++) {
     obj = obj ? obj[key[p]] : undef


### PR DESCRIPTION
If a key in the theme contains a dot (`.`) it could never be resolved because the get function woud split the string by that dot. E.g:

```js
const theme = {
  colors: {
    'my.color' : '#fff'
  }
}

// ...

<Box bg='my.color' />
```