### PR TITLE
ability to return an object of CSS properties in transform

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -147,7 +147,11 @@ export const createStyleFunction = ({
     const result = {}
     const n = transform(value, scale, _props)
     if (n === null) return
-    properties.forEach(prop => {
+    if (typeof n === 'object')
+      Object.keys(n).forEach(key => {
+        result[key] = n[key]
+      })
+    else properties.forEach(prop => {
       result[prop] = n
     })
     return result


### PR DESCRIPTION
This would allow props to apply different CSS values to multiple properties, based on the input value.

Right now the return value of `transform` is used as the CSS value for each property in `properties`. With this change, if the return value of `transform` is an object the keys and values will be applied as CSS. Allowing the assignment of different CSS values for multiple properties with one prop.