### PR TITLE
[Docs] Fix Artsy logo

### DIFF
--- a/docs/src/logos.mdx
+++ b/docs/src/logos.mdx
@@ -42,7 +42,7 @@ export default props =>
 <li>
   <img
     alt='Artsy logo'
-    src='https://erica-prince.com/wp-content/uploads/2018/08/artsy-logo.png'
+    src='https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Art.sylogo_2.tiff/lossless-page1-1200px-Art.sylogo_2.tiff.png'
     width='128'
   />
 </li>


### PR DESCRIPTION
Noticed that the Artsy logo was a broken image reference, so fixed that. Also noticed that there were no links out from the logos. 