### PR TITLE
docs(css): clarification for styled-components users

### DIFF
--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -41,7 +41,7 @@ const Boop = styled('div')(
 )
 ```
 
-To make the css prop work with `styled-components` `babel-plugin-styled-components` must be enabled.
+To make the css prop work with `styled-components`, `babel-plugin-styled-components` must be enabled.
 
 ## Theme Keys
 

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -41,6 +41,8 @@ const Boop = styled('div')(
 )
 ```
 
+To make the css prop work with `styled-components` `babel-plugin-styled-components` must be enabled.
+
 ## Theme Keys
 
 The following keys in your style object will work the same as Styled System props, pulling values from your `theme` object.


### PR DESCRIPTION
The css prop is a pretty niche feature in styled-components so a hint that you need to enable it via styled-components babel plugin would be helpful. 

More information [in this spectrum post](https://spectrum.chat/styled-system/general/styled-system-css-not-working~de0e9f4d-6e01-4d1d-87b4-56bf119e1e6f)