### PR TITLE
Custom media query breakpoints

### DIFF
--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -70,13 +70,16 @@ breakpoints.md = breakpoints[1]
 breakpoints.lg = breakpoints[2]
 breakpoints.xl = breakpoints[3]
 
+// alias for mobile media query using "pointer: coarse"
+breakpoints.mobile = '@media only screen and (pointer: coarse)'
+
 export default {
   breakpoints,
 }
 ```
 
 ```jsx
-<Box width={{ _: 1, sm: 1, md: 1 / 2, lg: 1 / 4 }} />
+<Box width={{ _: 1, sm: 1, md: 1 / 2, lg: 1 / 4, mobile: 2 }} />
 ```
 
 Read more in the [Array Props Guide](/guides/array-props).

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -28,7 +28,16 @@ const sort = obj => {
 const defaults = {
   breakpoints: [40, 52, 64].map(n => n + 'em'),
 }
-const createMediaQuery = n => `@media screen and (min-width: ${n})`
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+const stringStartsWith = (str, search) =>
+  str.substring(0, search.length) === search
+
+const createMediaQuery = n => {
+  if (typeof n === 'string' && stringStartsWith(n, '@media ')) {
+    return n
+  }
+  return `@media screen and (min-width: ${n})`
+}
 const getValue = (n, scale) => get(scale, n, n)
 
 export const get = (obj, key, def, p, undef) => {

--- a/packages/core/test/parser.js
+++ b/packages/core/test/parser.js
@@ -116,3 +116,27 @@ test('uses dynamically changed breakpoints', () => {
     },
   })
 })
+
+test('uses custom media query breakpoints', () => {
+  const styles = parser({
+    theme: {
+      disableStyledSystemCache: true,
+      fontSize: [0, 4, 8, 16],
+      breakpoints: [
+        '@media only screen and (pointer: fine)',
+        '@media only screen and (pointer: coarse)',
+      ],
+    },
+    fontSize: [1, 2, 3],
+  })
+  console.log({ styles })
+  expect(styles).toEqual({
+    fontSize: 4,
+    '@media only screen and (pointer: fine)': {
+      fontSize: 8,
+    },
+    '@media only screen and (pointer: coarse)': {
+      fontSize: 16,
+    },
+  })
+})

--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -144,13 +144,48 @@ const transforms = [
   {}
 )
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+const stringStartsWith = (str, search) =>
+  str.substring(0, search.length) === search
+
+const createMediaQuery = n => {
+  if (typeof n === 'string' && stringStartsWith(n, '@media ')) {
+    return n
+  }
+  return `@media screen and (min-width: ${n})`
+}
+
+/**
+ * Convert breakpoints into an array of media queries
+ * @param {array|object} breakpoints
+ * @returns {array}
+ */
+const createMediaQueries = breakpoints => {
+  /**
+   * Convert to array if not already. E.g:
+   * {
+   *   key-0: '@media ...',
+   *   key-1: '20em',
+   * }
+   * => ['@media ...', '20em']
+   */
+  breakpoints = !Array.isArray(breakpoints)
+    ? Object.values(breakpoints)
+    : breakpoints
+
+  const mediaQueries = Array(breakpoints.length + 1)
+  mediaQueries[0] = null
+
+  for (let i = 1, ii = mediaQueries.length; i < ii; ++i) {
+    mediaQueries[i] = createMediaQuery(breakpoints[i - 1])
+  }
+  return mediaQueries
+}
+
 export const responsive = styles => theme => {
   const next = {}
   const breakpoints = get(theme, 'breakpoints', defaultBreakpoints)
-  const mediaQueries = [
-    null,
-    ...breakpoints.map(n => `@media screen and (min-width: ${n})`),
-  ]
+  const mediaQueries = createMediaQueries(breakpoints)
 
   for (const key in styles) {
     const value =
@@ -159,9 +194,36 @@ export const responsive = styles => theme => {
     if (value == null) continue
     if (!Array.isArray(value)) {
       next[key] = value
+
+      if (typeof breakpoints === 'object' && typeof value === 'object') {
+        // It's possible this object is simply a nested selector,
+        // such as `h1: {...}`, and not a breakpoint object
+        let isBreakpointObj = false
+
+        for (let bpkey in value) {
+          let media = breakpoints[bpkey]
+
+          // Check if key is a breakpoint key
+          if (!media) {
+            continue
+          }
+          isBreakpointObj = true
+
+          // Apply the breakpoint value to the result['@media...'] object
+          next[media] = next[media] || {}
+          next[media][key] = value[bpkey]
+        }
+
+        if (isBreakpointObj) {
+          // Replace the result object with the default value (can be undefined)
+          next[key] = next[key]._
+        }
+      }
       continue
     }
-    for (let i = 0; i < value.slice(0, mediaQueries.length).length; i++) {
+
+    const length = value.slice(0, mediaQueries.length).length
+    for (let i = 0; i < length; i++) {
       const media = mediaQueries[i]
       if (value[i] == null) continue
       if (!media) {

--- a/packages/css/test/index.js
+++ b/packages/css/test/index.js
@@ -259,13 +259,13 @@ test('handles negative top, left, bottom, and right from scale', () => {
 
 test('skip breakpoints', () => {
   const result = css({
-    width: [ '100%', , '50%' ],
+    width: ['100%', , '50%'],
   })(theme)
   expect(result).toEqual({
     width: '100%',
     '@media screen and (min-width: 52em)': {
       width: '50%',
-    }
+    },
   })
 })
 
@@ -290,9 +290,9 @@ test('padding shorthand does not collide with nested p selector', () => {
 
 test('ignores array values longer than breakpoints', () => {
   const result = css({
-    width: [ 32, 64, 128, 256, 512 ]
+    width: [32, 64, 128, 256, 512],
   })({
-    breakpoints: [ '32em', '40em' ],
+    breakpoints: ['32em', '40em'],
   })
   expect(result).toEqual({
     width: 32,
@@ -403,6 +403,85 @@ test('returns outline color from theme', () => {
     outlineColor: 'primary',
   })(theme)
   expect(result).toEqual({
-    outlineColor: 'tomato'
+    outlineColor: 'tomato',
+  })
+})
+
+test('custom media query breakpoints object', () => {
+  const result = css({
+    fontSize: {
+      _: 16,
+      'break-0': 32,
+      'break-1': 64,
+    },
+    lineHeight: {
+      /* test no default */
+      'break-1': 128,
+    },
+
+    h1: {
+      fontSize: {
+        _: 500,
+        'break-1': 750,
+        'break-2': 1000,
+      },
+    },
+  })({
+    breakpoints: {
+      'break-0': '@media screen and (min-width: 40em)',
+      'break-1': '@media screen and (min-width: 52em)',
+      'break-2': '@media screen and (min-width: 90em)',
+    },
+  })
+  expect(result).toEqual({
+    fontSize: 16,
+    '@media screen and (min-width: 40em)': {
+      fontSize: 32,
+    },
+    '@media screen and (min-width: 52em)': {
+      fontSize: 64,
+      lineHeight: 128,
+    },
+    h1: {
+      fontSize: 500,
+      '@media screen and (min-width: 52em)': {
+        fontSize: 750,
+      },
+      '@media screen and (min-width: 90em)': {
+        fontSize: 1000,
+      },
+    },
+  })
+})
+
+test('custom media query breakpoints array', () => {
+  const result = css({
+    fontSize: [16, 32, 64],
+    lineHeight: [32, null, 128],
+    h1: {
+      lineHeight: [256, 512, null],
+    },
+  })({
+    breakpoints: [
+      '@media screen and (min-width: 40em)',
+      '@media screen and (min-width: 52em)',
+    ],
+  })
+  expect(result).toEqual({
+    fontSize: 16,
+    lineHeight: 32,
+    '@media screen and (min-width: 40em)': {
+      fontSize: 32,
+    },
+    '@media screen and (min-width: 52em)': {
+      fontSize: 64,
+      lineHeight: 128,
+    },
+    h1: {
+      lineHeight: 256,
+      '@media screen and (min-width: 40em)': {
+        lineHeight: 512,
+      },
+    },
   })
 })


### PR DESCRIPTION
Allows consumers to have more control over the media queries that get matched against by allowing custom `@media ...` queries in place of basic `em` rule matching. For example, these rules can be used to distinguish touch/mobile devices using `pointer: coarse`

Media queries can be used in a `breakpoints` array and matched against:
```
const theme = {
  breakpoints: ['@media ...', '@media ...']
}

const style = css({
  fontSize: [1, 2, 3]
})(theme)
```

`breakpoints` can also be an object with media queries as the keys
```
const theme = {
  breakpoints: {
    'break-0': '@media ...',
    'break-1': '@media ...',
  }
}

const style = css({
  fontSize: {
    _: 1,
    'break-0': 2,
    'break-1': 3
  }
})(theme)
```

Both `style`s above are equivalent to:
```
{
  fontSize: 1,
  '@media ...': {
    fontSize: 2
  },
  '@media ...': {
    fontSize: 3
  }
}
```



