### PR TITLE
Fix media query when using css package with null responsive values

### DIFF
--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -163,12 +163,12 @@ export const responsive = styles => theme => {
     }
     for (let i = 0; i < value.slice(0, mediaQueries.length).length; i++) {
       const media = mediaQueries[i]
-      if (value[i] == null) continue
       if (!media) {
         next[key] = value[i]
         continue
       }
       next[media] = next[media] || {}
+      if (value[i] == null) continue
       next[media][key] = value[i]
     }
   }

--- a/packages/css/test/index.js
+++ b/packages/css/test/index.js
@@ -263,6 +263,7 @@ test('skip breakpoints', () => {
   })(theme)
   expect(result).toEqual({
     width: '100%',
+    '@media screen and (min-width: 40em)': {},
     '@media screen and (min-width: 52em)': {
       width: '50%',
     }
@@ -405,4 +406,53 @@ test('returns outline color from theme', () => {
   expect(result).toEqual({
     outlineColor: 'tomato'
   })
+})
+
+test('returns correct media query order', () => {
+  const result = css({
+    width: ['100%', , '50%'],
+    color: ['red', 'green', 'blue'],
+  })(theme)
+  const keys = Object.keys(result)
+  expect(keys).toEqual([
+    'width',
+    '@media screen and (min-width: 40em)',
+    '@media screen and (min-width: 52em)',
+    'color',
+  ])
+  expect(result).toEqual({
+    width: '100%',
+    '@media screen and (min-width: 40em)': {
+      color: 'green',
+    },
+    '@media screen and (min-width: 52em)': {
+      width: '50%',
+      color: 'blue',
+    },
+    color: 'red',
+  })
+})
+
+test('returns correct media query order 2', () => {
+  const result = css({
+    flexDirection: 'column',
+    justifyContent: [null, 'flex-start', 'flex-end'],
+    color: 'background',
+    height: '100%',
+    px: [2, 3, 4],
+    py: 4,
+  })(theme)
+  const keys = Object.keys(result)
+  expect(keys).toEqual([
+    'flexDirection',
+    'justifyContent',
+    '@media screen and (min-width: 40em)',
+    '@media screen and (min-width: 52em)',
+    'color',
+    'height',
+    'paddingLeft',
+    'paddingRight',
+    'paddingTop',
+    'paddingBottom',
+  ])
 })


### PR DESCRIPTION
Hi,

Noticed an issue with responsive arrays when using @styled-system/css today. When null values are passed in, the order that the media queries are loaded in, can be out of order.

A detail of the issue and what is happening is in the issue https://github.com/system-ui/theme-ui/issues/577 on theme-ui project.

I looked through many issues in this repo where it was bought up, #551, #561 and #813. 

I noticed it was fixed in theme ui with PR https://github.com/system-ui/theme-ui/pull/600

This is a port of that fix, with the added tests also.

I don't have full context over the reason it may or may not have been ported from theme-ui, since it seems the css package there is identical to this one, minus this fix.