### PR TITLE
Update `createPropTypes` from O(n^2) to O(n)

### DIFF
--- a/packages/prop-types/src/index.js
+++ b/packages/prop-types/src/index.js
@@ -23,10 +23,10 @@ export const propType = PropTypes.oneOfType([
 ])
 
 export const createPropTypes = props => {
-  return props.reduce((acc, name) => ({
-  ...acc,
-  [name]: propType,
-}), {})
+  return props.reduce((acc, name) => {
+    acc[name] = propType
+    return acc
+  }, {})
 }
 
 export default {


### PR DESCRIPTION
I noticed `createPropTypes` was spreading the accumulator every loop. I realize this is a micro-optimization but why not. More details: https://medium.com/better-programming/the-reduce-spread-anti-pattern-fc0c1c0b23f6