### PR TITLE
[Grid] Add non-prefixed grid gap

### DIFF
--- a/packages/grid/src/index.js
+++ b/packages/grid/src/index.js
@@ -10,6 +10,11 @@ const config = {
     scale: 'space',
     defaultScale: defaults.space,
   },
+  gap: {
+    property: 'gap',
+    scale: 'space',
+    defaultScale: defaults.space,
+  },
   gridColumnGap: {
     property: 'gridColumnGap',
     scale: 'space',

--- a/packages/grid/test/index.js
+++ b/packages/grid/test/index.js
@@ -8,3 +8,12 @@ test('returns grid styles', () => {
     gridGap: 32,
   })
 })
+
+test('returns gap styles', () => {
+  const style = grid({
+    gap: 32,
+  })
+  expect(style).toEqual({
+    gap: 32,
+  })
+})


### PR DESCRIPTION
Addition of non-prefixed grid `gap` was added in CSS package in #596, however wasn't added to Grid package. This PR finishes that addition.