### PR TITLE
Remove object-assign from styled-system dependencies

### DIFF
--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -24,8 +24,7 @@
     "@styled-system/shadow": "^5.1.2",
     "@styled-system/space": "^5.1.2",
     "@styled-system/typography": "^5.1.2",
-    "@styled-system/variant": "^5.1.5",
-    "object-assign": "^4.1.1"
+    "@styled-system/variant": "^5.1.5"
   },
   "gitHead": "a6feb6009c58f2eb68f0c3120c5672f6cb54294f",
   "devDependencies": {


### PR DESCRIPTION
Doesn't seem to be used.