### PR TITLE
store config properties on styleFunctions

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -152,6 +152,8 @@ export const createStyleFunction = ({
     })
     return result
   }
+  sx.properties = properties
+  sx.transform = transform
   sx.scale = scale
   sx.defaults = defaultScale
   return sx


### PR DESCRIPTION
Instead of completely overriding the config with the style functions, keeping the original config values on the styleFunctions makes them easy to extend with simple middleware.

≈
```
  ...
  newConfig.paddingX = createStyleFunction({
        properties: newConfig.paddingX.properties,
        scale: newConfig.paddingX.scale,
        transform: (n, theme) => {
            // do stuff here.
             return newConfig.paddingX.transform(n, theme)
        }
})
```

Alternatively, exporting the original config objects makes it easy to extend as well? 