### PR TITLE
fix: prevent undefined values of overwriting existing styles

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -12,23 +12,25 @@ export const merge = (a, b) => {
 }
 
 // sort object-value responsive styles
-const sort = obj => {
+const sort = (obj) => {
   const next = {}
   Object.keys(obj)
-    .sort((a, b) => a.localeCompare(b, undefined, {
-      numeric: true,
-      sensitivity: 'base',
-    }))
-    .forEach(key => {
+    .sort((a, b) =>
+      a.localeCompare(b, undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      })
+    )
+    .forEach((key) => {
       next[key] = obj[key]
     })
   return next
 }
 
 const defaults = {
-  breakpoints: [40, 52, 64].map(n => n + 'em'),
+  breakpoints: [40, 52, 64].map((n) => n + 'em'),
 }
-const createMediaQuery = n => `@media screen and (min-width: ${n})`
+const createMediaQuery = (n) => `@media screen and (min-width: ${n})`
 const getValue = (n, scale) => get(scale, n, n)
 
 export const get = (obj, key, def, p, undef) => {
@@ -39,15 +41,15 @@ export const get = (obj, key, def, p, undef) => {
   return obj === undef ? def : obj
 }
 
-export const createParser = config => {
+export const createParser = (config) => {
   const cache = {}
-  const parse = props => {
+  const parse = (props) => {
     let styles = {}
     let shouldSort = false
     const isCacheDisabled = props.theme && props.theme.disableStyledSystemCache
 
     for (const key in props) {
-      if (!config[key]) continue
+      if (!config[key] || props[key] === undefined) continue
       const sx = config[key]
       const raw = props[key]
       const scale = get(props.theme, sx.scale, sx.defaults)
@@ -91,9 +93,9 @@ export const createParser = config => {
   parse.propNames = Object.keys(config)
   parse.cache = cache
 
-  const keys = Object.keys(config).filter(k => k !== 'config')
+  const keys = Object.keys(config).filter((k) => k !== 'config')
   if (keys.length > 1) {
-    keys.forEach(key => {
+    keys.forEach((key) => {
       parse[key] = createParser({ [key]: config[key] })
     })
   }
@@ -147,7 +149,7 @@ export const createStyleFunction = ({
     const result = {}
     const n = transform(value, scale, _props)
     if (n === null) return
-    properties.forEach(prop => {
+    properties.forEach((prop) => {
       result[prop] = n
     })
     return result
@@ -160,7 +162,7 @@ export const createStyleFunction = ({
 // new v5 API
 export const system = (args = {}) => {
   const config = {}
-  Object.keys(args).forEach(key => {
+  Object.keys(args).forEach((key) => {
     const conf = args[key]
     if (conf === true) {
       // shortcut definition
@@ -183,7 +185,7 @@ export const system = (args = {}) => {
 
 export const compose = (...parsers) => {
   let config = {}
-  parsers.forEach(parser => {
+  parsers.forEach((parser) => {
     if (!parser || !parser.config) return
     assign(config, parser.config)
   })

--- a/packages/core/test/system.js
+++ b/packages/core/test/system.js
@@ -140,11 +140,11 @@ test('gets 0 index values from theme', () => {
     width: {
       property: 'width',
       scale: 'sizes',
-    }
+    },
   })
   const style = parser({
     theme: {
-      sizes: [ 24, 48 ],
+      sizes: [24, 48],
     },
     width: 0,
   })
@@ -159,6 +159,25 @@ test('ignores null values', () => {
   expect(style).toEqual({})
 })
 
+test('ignores undefined values', () => {
+  const parser = system({
+    variant: () => ({
+      color: 'red',
+    }),
+    color: true,
+  })
+  const style = parser({ variant: 'red', color: undefined })
+  expect(style).toEqual({ color: 'red' })
+})
+
+test('ignores undefined values', () => {
+  const parser = system({
+    color: true,
+  })
+  const style = parser({ color: undefined })
+  expect(style).toEqual({})
+})
+
 test('returns a noop function with no arguments', () => {
   const parser = system()
   expect(typeof parser).toBe('function')
@@ -169,7 +188,7 @@ test('skips null values in arrays', () => {
     fontSize: true,
   })
   const style = parser({
-    fontSize: [ 16, null, null, 18 ],
+    fontSize: [16, null, null, 18],
   })
   expect(style).toEqual({
     fontSize: 16,
@@ -179,7 +198,7 @@ test('skips null values in arrays', () => {
     '@media screen and (min-width: 52em)': {},
     '@media screen and (min-width: 64em)': {
       fontSize: 18,
-    }
+    },
   })
 })
 
@@ -189,8 +208,12 @@ test('includes single property functions', () => {
     backgroundColor: true,
     width: true,
   })
-  const a = parser.color({ color: 'tomato', backgroundColor: 'nope'  })
-  const b = parser.width({ width: '100%', color: 'tomato', backgroundColor: 'nope'  })
+  const a = parser.color({ color: 'tomato', backgroundColor: 'nope' })
+  const b = parser.width({
+    width: '100%',
+    color: 'tomato',
+    backgroundColor: 'nope',
+  })
   expect(a).toEqual({ color: 'tomato' })
   expect(b).toEqual({ width: '100%' })
 })
@@ -224,7 +247,7 @@ test('supports non-array breakpoints object', () => {
         sm: '32em',
         md: '40em',
         lg: '64em',
-      }
+      },
     },
     margin: { _: 0, sm: 4, md: 8 },
     padding: { _: 16, lg: 64 },
@@ -258,7 +281,7 @@ test('sorts media queries when responsive object values are used', () => {
         md: '40em',
         lg: '64em',
         xl: '128em',
-      }
+      },
     },
     padding: { _: 16, lg: 64, xl: 128 },
     margin: { sm: 4, md: 8 },
@@ -280,8 +303,8 @@ test('transforms values', () => {
       transform: (n, scale, props) => {
         const m = props.multiply || 1
         return m * n
-      }
-    }
+      },
+    },
   })
   const a = parser({ margin: 8 })
   const b = parser({ margin: 12, multiply: 2 })


### PR DESCRIPTION
I have this issue with styled-components that if you have a variant that sets certain style attrs, but then also allow to overwrite a specific attr (e.g. color) then the style from the variant gets overwritten by `undefined`. I think the test I added explains it pretty well.

There was a bunch of prettier updates that I can revert if you'd like