### PR TITLE
position: Use space scale for negative numbers

### DIFF
--- a/packages/position/src/index.js
+++ b/packages/position/src/index.js
@@ -1,7 +1,23 @@
-import { system } from '@styled-system/core'
+import { get, system } from '@styled-system/core'
 
 const defaults = {
   space: [0, 4, 8, 16, 32, 64, 128, 256, 512],
+}
+
+const isNumber = (n) => typeof n === 'number' && !isNaN(n)
+
+const getPosition = (n, scale) => {
+  if (!isNumber(n)) {
+    return get(scale, n, n)
+  }
+
+  const isNegative = n < 0
+  const absolute = Math.abs(n)
+  const value = get(scale, absolute, absolute)
+  if (!isNumber(value)) {
+    return isNegative ? '-' + value : value
+  }
+  return value * (isNegative ? -1 : 1)
 }
 
 const config = {
@@ -13,21 +29,25 @@ const config = {
   top: {
     property: 'top',
     scale: 'space',
+    transform: getPosition,
     defaultScale: defaults.space,
   },
   right: {
     property: 'right',
     scale: 'space',
+    transform: getPosition,
     defaultScale: defaults.space,
   },
   bottom: {
     property: 'bottom',
     scale: 'space',
+    transform: getPosition,
     defaultScale: defaults.space,
   },
   left: {
     property: 'left',
     scale: 'space',
+    transform: getPosition,
     defaultScale: defaults.space,
   },
 }

--- a/packages/position/test/index.js
+++ b/packages/position/test/index.js
@@ -18,6 +18,11 @@ test('returns theme values', () => {
   expect(style).toEqual({ top: 4, right: 8, bottom: 16, left: 32 })
 })
 
+test('returns negative theme values', () => {
+  const style = position({ top: -1, right: -2, bottom: -3, left: -4 })
+  expect(style).toEqual({ top: -4, right: -8, bottom: -16, left: -32 })
+})
+
 test('returns pixel values', () => {
   const style = position({
     top: '1px',


### PR DESCRIPTION
Uses the same transform as used by `margin` in the `space` package so negative values can be used to reference the theme for top/right/bottom/left.

Fixes #1458