### PR TITLE
prop-types: Complete list of available type categories in readme

### DIFF
--- a/packages/prop-types/README.md
+++ b/packages/prop-types/README.md
@@ -31,6 +31,10 @@ Box.propTypes = {
 * `background`
 * `position`
 * `grid`
+* `shadow`
+* `buttonStyle`
+* `textStyle`
+* `colorStyle`
 
 See props of each category in [the reference table](https://styled-system.com/table).
 


### PR DESCRIPTION
`shadow`, `buttonStyle`, `textStyle`, and `colorStyle` properties are
all available on the default export of this package but were missing
from the list in the readme.

https://github.com/styled-system/styled-system/blob/bf6218e8f7a368399371b11265da2b17a4728475/packages/prop-types/src/index.js#L32-L46