### PR TITLE
impr(space): support negative space aliases for margin props

### DIFF
--- a/packages/space/src/index.js
+++ b/packages/space/src/index.js
@@ -4,11 +4,31 @@ const defaults = {
   space: [0, 4, 8, 16, 32, 64, 128, 256, 512],
 }
 
-const isNumber = n => typeof n === 'number' && !isNaN(n)
+const isNumber = (n) => typeof n === 'number' && !isNaN(n)
 
 const getMargin = (n, scale) => {
   if (!isNumber(n)) {
-    return get(scale, n, n)
+    const value = get(scale, n, n)
+
+    if (!isNumber(value)) {
+      const isNegative =
+        typeof value === 'string' ? value.startsWith('-') : false
+
+      if (!isNegative) {
+        return value
+      }
+
+      const absolute = value.slice(1)
+      const absoluteValue = get(scale, absolute, absolute)
+
+      if (!isNumber(absoluteValue)) {
+        return value
+      }
+
+      return absoluteValue * -1
+    }
+
+    return value
   }
 
   const isNegative = n < 0

--- a/packages/space/test/index.js
+++ b/packages/space/test/index.js
@@ -191,7 +191,7 @@ test('supports object values', () => {
       _: 0,
       0: 1,
       1: 2,
-    }
+    },
   })
   expect(styles).toEqual({
     margin: 0,
@@ -210,7 +210,7 @@ test('supports non-array breakpoints', () => {
     breakpoints: {
       small: '40em',
       medium: '52em',
-    }
+    },
   }
   const styles = space({
     theme,
@@ -221,7 +221,7 @@ test('supports non-array breakpoints', () => {
       _: 0,
       small: 1,
       medium: 2,
-    }
+    },
   })
   expect(styles).toEqual({
     margin: 0,
@@ -232,5 +232,49 @@ test('supports non-array breakpoints', () => {
     '@media screen and (min-width: 52em)': {
       margin: 8,
     },
+  })
+})
+
+test('supports non-array spacing', () => {
+  const theme = {
+    disableStyledSystemCache: true,
+    space: {
+      s: 4,
+      m: 8,
+      l: 12,
+    },
+  }
+  const styles = space({
+    theme,
+    p: 's',
+    m: 'm',
+  })
+  expect(styles).toEqual({
+    padding: 4,
+    margin: 8,
+  })
+})
+
+test('supports non-array spacing and negative theme value', () => {
+  const theme = {
+    disableStyledSystemCache: true,
+    space: {
+      s: 4,
+      m: 8,
+      l: 12,
+    },
+  }
+  const styles = space({
+    theme,
+    mt: 's',
+    mr: '-m',
+    mb: '-l',
+    ml: 'm',
+  })
+  expect(styles).toEqual({
+    marginTop: 4,
+    marginRight: -8,
+    marginBottom: -12,
+    marginLeft: 8,
   })
 })


### PR DESCRIPTION
_It's my first contribution to this project, please do let me know if there are some rules that I need to follow_

Today `styled-system` supports aliases which is pretty awesome and it also supports negative margin values such as `-16px` and `-1em` but unfortunately it didn't support the combination of both.

With this PR, we'd be able to use something like:

```JS
<Box mt="-s" />
```

And it should work pretty much the same for responsive values:

```JS
<Box mt={["-s", "m", "-l"]} />
```

Please do let me know if it's something that could be added to the library itself more maybe it's a very custom logic in which case I will just add it directly to my project.

Thank you
