### PR TITLE
Docs: Fix Array Props Guide link in responsive-styles.md

### DIFF
--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -79,4 +79,4 @@ export default {
 <Box width={{ _: 1, sm: 1, md: 1 / 2, lg: 1 / 4 }} />
 ```
 
-Read more in the [Array Props Guide](/guides/array-props).
+Read more in the [Array Props Guide](./guides/array-props.md).


### PR DESCRIPTION
Small fix for the responsive-styles doc, the link pointed to non-existent location