### PR TITLE
Improve css function performance

### DIFF
--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -1,20 +1,38 @@
 // based on https://github.com/developit/dlv
-export const get = (obj, key, def, p, undef) => {
-  key = key && key.split ? key.split('.') : [key]
+export var get = function get(obj, key, def, p, undef) {
+  var _key;
+
+  key = (_key = key) != null && _key.split ? key.split('.') : [key];
+
   for (p = 0; p < key.length; p++) {
-    obj = obj ? obj[key[p]] : undef
+    var _obj;
+
+    obj = ((_obj = obj) == null ? void 0 : _obj[key[p]]) || undef;
   }
-  return obj === undef ? def : obj
-}
 
-const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
+  return obj === undef ? def : obj;
+};
 
-const defaultTheme = {
+var assign = function assign(target) {
+  for (var i = 0; i < (arguments.length <= 1 ? 0 : arguments.length - 1); i += 1) {
+    var other = i + 1 < 1 || arguments.length <= i + 1 ? undefined : arguments[i + 1];
+    var keys = Object.keys(other);
+
+    for (var j = 0; j < keys.length; j += 1) {
+      var key = keys[j];
+      target[key] = other[key];
+    }
+  }
+
+  return target;
+};
+
+var defaultBreakpoints = ['40em', '52em', '64em'];
+var defaultTheme = {
   space: [0, 4, 8, 16, 32, 64, 128, 256, 512],
-  fontSizes: [12, 14, 16, 20, 24, 32, 48, 64, 72],
-}
-
-const aliases = {
+  fontSizes: [12, 14, 16, 20, 24, 32, 48, 64, 72]
+};
+var aliases = {
   bg: 'backgroundColor',
   m: 'margin',
   mt: 'marginTop',
@@ -29,18 +47,16 @@ const aliases = {
   pb: 'paddingBottom',
   pl: 'paddingLeft',
   px: 'paddingX',
-  py: 'paddingY',
-}
-
-const multiples = {
+  py: 'paddingY'
+};
+var multiples = {
   marginX: ['marginLeft', 'marginRight'],
   marginY: ['marginTop', 'marginBottom'],
   paddingX: ['paddingLeft', 'paddingRight'],
   paddingY: ['paddingTop', 'paddingBottom'],
-  size: ['width', 'height'],
-}
-
-const scales = {
+  size: ['width', 'height']
+};
+var scales = {
   color: 'colors',
   backgroundColor: 'colors',
   borderColor: 'colors',
@@ -111,110 +127,129 @@ const scales = {
   size: 'sizes',
   // svg
   fill: 'colors',
-  stroke: 'colors',
-}
+  stroke: 'colors'
+};
 
-const positiveOrNegative = (scale, value) => {
+var positiveOrNegative = function positiveOrNegative(scale, value) {
   if (typeof value !== 'number' || value >= 0) {
-    return get(scale, value, value)
+    return get(scale, value, value);
   }
-  const absolute = Math.abs(value)
-  const n = get(scale, absolute, absolute)
-  if (typeof n === 'string') return '-' + n
-  return n * -1
-}
 
-const transforms = [
-  'margin',
-  'marginTop',
-  'marginRight',
-  'marginBottom',
-  'marginLeft',
-  'marginX',
-  'marginY',
-  'top',
-  'bottom',
-  'left',
-  'right',
-].reduce(
-  (acc, curr) => ({
-    ...acc,
-    [curr]: positiveOrNegative,
-  }),
-  {}
-)
+  var absolute = Math.abs(value);
+  var n = get(scale, absolute, absolute);
+  if (typeof n === 'string') return '-' + n;
+  return n * -1;
+};
 
-export const responsive = styles => theme => {
-  const next = {}
-  const breakpoints = get(theme, 'breakpoints', defaultBreakpoints)
-  const mediaQueries = [
-    null,
-    ...breakpoints.map(n => `@media screen and (min-width: ${n})`),
-  ]
+var transforms = {
+  'margin': positiveOrNegative,
+  'marginTop': positiveOrNegative,
+  'marginRight': positiveOrNegative,
+  'marginBottom': positiveOrNegative,
+  'marginLeft': positiveOrNegative,
+  'marginX': positiveOrNegative,
+  'marginY': positiveOrNegative,
+  'top': positiveOrNegative,
+  'bottom': positiveOrNegative,
+  'left': positiveOrNegative,
+  'right': positiveOrNegative
+};
+export var responsive = function responsive(styles) {
+  return function (theme) {
+    var next = {};
+    var breakpoints = get(theme, 'breakpoints', defaultBreakpoints);
+    var breakpointsLength = breakpoints.length;
+    var mediaQueries = new Array(breakpointsLength + 1);
+    mediaQueries[0] = null;
 
-  for (const key in styles) {
-    const value =
-      typeof styles[key] === 'function' ? styles[key](theme) : styles[key]
-
-    if (value == null) continue
-    if (!Array.isArray(value)) {
-      next[key] = value
-      continue
+    for (var j = 0; j < breakpointsLength; j += 1) {
+      mediaQueries[j + 1] = "@media screen and (min-width: " + breakpoints[j] + ")";
     }
-    for (let i = 0; i < value.slice(0, mediaQueries.length).length; i++) {
-      const media = mediaQueries[i]
-      if (!media) {
-        next[key] = value[i]
-        continue
+
+    if (typeof styles !== 'object' || styles === null) return {};
+    var keys = Object.keys(styles);
+
+    for (var i = 0; i < keys.length; i += 1) {
+      var key = keys[i];
+      var value = typeof styles[key] === 'function' ? styles[key](theme) : styles[key];
+      if (value == null) continue;
+
+      if (!Array.isArray(value)) {
+        next[key] = value;
+        continue;
       }
-      next[media] = next[media] || {}
-      if (value[i] == null) continue
-      next[media][key] = value[i]
-    }
-  }
 
-  return next
-}
+      var len = Math.min(value.length, mediaQueries.length);
 
-export const css = args => (props = {}) => {
-  const theme = { ...defaultTheme, ...(props.theme || props) }
-  let result = {}
-  const obj = typeof args === 'function' ? args(theme) : args
-  const styles = responsive(obj)(theme)
+      for (var _i = 0; _i < len; _i += 1) {
+        var media = mediaQueries[_i];
 
-  for (const key in styles) {
-    const x = styles[key]
-    const val = typeof x === 'function' ? x(theme) : x
+        if (!media) {
+          next[key] = value[_i];
+          continue;
+        }
 
-    if (key === 'variant') {
-      const variant = css(get(theme, val))(theme)
-      result = { ...result, ...variant }
-      continue
-    }
-
-    if (val && typeof val === 'object') {
-      result[key] = css(val)(theme)
-      continue
-    }
-
-    const prop = get(aliases, key, key)
-    const scaleName = get(scales, prop)
-    const scale = get(theme, scaleName, get(theme, prop, {}))
-    const transform = get(transforms, prop, get)
-    const value = transform(scale, val, val)
-
-    if (multiples[prop]) {
-      const dirs = multiples[prop]
-      
-      for (let i = 0; i < dirs.length; i++) {
-        result[dirs[i]] = value
+        next[media] = next[media] || {};
+        if (value[_i] == null) continue;
+        next[media][key] = value[_i];
       }
-    } else {
-      result[prop] = value
     }
-  }
 
-  return result
-}
+    return next;
+  };
+};
 
-export default css
+var css = function css(args) {
+  return function (props) {
+    if (props === void 0) {
+      props = {};
+    }
+
+    var theme = assign(Object.create(null), defaultTheme, props.theme || props);
+    var result = Object.create(null);
+    traverse(args, result);
+
+    function traverse(_args, carry) {
+      var obj = typeof _args === 'function' ? _args(theme) : _args;
+      var styles = responsive(obj)(theme);
+      var keys = Object.keys(styles);
+
+      for (var i = 0; i < keys.length; i += 1) {
+        var key = keys[i];
+        var val = styles[key];
+        val = typeof val === 'function' ? val(theme) : val;
+
+        if (key === 'variant') {
+          traverse(get(theme, val), carry);
+          continue;
+        }
+
+        if (typeof val === 'object') {
+          var child = carry[key] = Object.create(null);
+          traverse(val, child);
+          continue;
+        }
+
+        var prop = get(aliases, key, key);
+        var scaleName = get(scales, prop);
+        var scale = get(theme, scaleName, get(theme, prop, {}));
+        var transform = get(transforms, prop, get);
+        var value = transform(scale, val, val);
+
+        if (multiples[prop]) {
+          var dirs = multiples[prop];
+
+          for (var j = 0; j < dirs.length; j += 1) {
+            carry[dirs[j]] = value;
+          }
+        } else {
+          carry[prop] = value;
+        }
+      }
+    }
+
+    return result;
+  };
+};
+
+export default css;


### PR DESCRIPTION
This PR aims to improve the performance of the `css` function significantly. 

We've found that the `css` function is a major contributor that harms the LCP and runtime performance of our site, so every bit of performance gain from micro tuning matters.

Currently there're a few performance bottlenecks:

1. Object merging. The spread operator used to merge objects will be transpiled to `Object.assign` by Babel. This is not optimal in terms of performance. A raw `for` loop will be much more performant. Run this test to find out the difference:
```js
const assign = (target, ...sources) => {
    for (let i = 0; i < sources.length; i++) {
        const source = sources[i];
        const keys = Object.keys(source);
        for (let j = 0; j < keys.length; j++) {
            const key = keys[j];
            target[key] = source[key];
        }
    }

    return target
}

const randStr = len => Math.random().toString(36).substr(2, len)
const createObj = () => new Array(600).fill(null).reduce((obj, _, idx) => {
    obj[`${randStr(6)}-${idx}`] = randStr(10)
    return obj
}, {})

const o1 = createObj();
const o2 = createObj();

console.time('assign')
for (let i = 0; i < 1000; i++) {
    assign({}, o1, o2)
}
console.timeEnd('assign')

console.time('Object.assign')
for (let i = 0; i < 1000; i++) {
    Object.assign({}, o1, o2)
}
console.timeEnd('Object.assign')
```

2. The recursion of `css` is very inefficient. It recreates `theme`(which is expensive to calculate) and copies the same `result` in every iteration. By initiating the `theme` once and mutating the `result` in place, we can gain a huge perf improvement.
