### PR TITLE
Update gridTemplateAreas example snippet.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -279,7 +279,7 @@ The `grid` utility includes style props for `gridGap`, `gridColumnGap`, `gridRow
 <Box gridTemplateRows='auto' />
 
 // gridTemplateAreas
-<Box gridTemplateAreas='a b' />
+<Box gridTemplateAreas=' "a a b" "a a b" "c c c" ' />
 
 // gridArea
 <Box gridArea='a' />


### PR DESCRIPTION
The example snippet for the gridTemplateAreas attribute is somewhat ambiguous and can lead to confusion. Each defined area must be a string and the entire value must be wrapped in quotes of some kind. The only thing I could find online re:the correct syntax was a single issue posted to the Github repository from 2019. I believe a more thorough example snippet would be helpful to new users of the framework.