### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/color"
+  },
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/core"
+  },
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
   "gitHead": "a6feb6009c58f2eb68f0c3120c5672f6cb54294f",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/grid"
+  },
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {

--- a/packages/prop-types/package.json
+++ b/packages/prop-types/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.5",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/prop-types"
+  },
   "author": "Brent Jackson",
   "license": "MIT",
   "peerDependencies": {

--- a/packages/props/package.json
+++ b/packages/props/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.5",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/props"
+  },
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {

--- a/packages/shadow/package.json
+++ b/packages/shadow/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/shadow"
+  },
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {

--- a/packages/should-forward-prop/package.json
+++ b/packages/should-forward-prop/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.5",
   "description": "Utility for filtering Styled System props with Emotion's shouldForwardProp option",
   "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/should-forward-prop"
+  },
   "module": "dist/index.esm.js",
   "keywords": [],
   "author": "Brent Jackson <jxnblk@gmail.com>",

--- a/packages/space/package.json
+++ b/packages/space/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/space"
+  },
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
   "gitHead": "a6feb6009c58f2eb68f0c3120c5672f6cb54294f",

--- a/packages/theme-get/package.json
+++ b/packages/theme-get/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/theme-get"
+  },
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/packages/variant/package.json
+++ b/packages/variant/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.5",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/styled-system/styled-system.git",
+    "directory": "packages/variant"
+  },
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @styled-system/variant
* @styled-system/theme-get
* @styled-system/space
* @styled-system/should-forward-prop
* @styled-system/shadow
* @styled-system/prop-types
* @styled-system/props
* @styled-system/grid
* @styled-system/core
* @styled-system/color