### PR TITLE
url fixes for reference-table and responsive-styles links on getting-started.md file

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -222,5 +222,5 @@ For a complete list, see the [Reference Table][] of style functions.
 
 [styled components]: https://github.com/styled-components/styled-components
 [emotion]: https://github.com/emotion-js/emotion
-[responsive styles]: /responsive-styles
-[reference table]: /table
+[responsive styles]: ./responsive-styles
+[reference table]: ./table


### PR DESCRIPTION
the reference table and the responsive-styles links were not working. changed the links from /table to ./table and /responsive-styles to ./responsive-styles and they work properly